### PR TITLE
Making it official

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,13 @@
+**Status Update — Sunday, September 4 2011**
+
+In order to make it easier for new users to choose a canonical fork of ShareKit, the ShareKit community has decided to band together and take responsibility for collecting useful commits into what we're calling "ShareKit 2.0". In the next week or two, we'll be working to test and release the first officially stable version of ShareKit since February, with more frequent updates expected thereafter.
+
+You can follow the initial planning at https://github.com/ideashower/ShareKit/issues/283.
+
+Many thanks to @ideashower for birthing ShareKit. Pending more relevant instructions, here is his original ReadMe, unedited. We'll have more up-to-date instructions posted here soon: https://github.com/ShareKit/ShareKit.
+
+----
+
 The code hosted here on github is for ongoing development and contributions  and may contain untested code.  Please use a stable release from http://getsharekit.com for use in your own app.
 
 ## Further installation instructions:


### PR DESCRIPTION
Here's a first stab at making our intentions for ShareKit official. Once we're ready to announce a stable version, along with perhaps some ground rules for the ShareKit organization*, I'd like to replace the old readme in its entirety in order to attract more attention. For now, I think we're still in a somewhat confused place as far as new users are concerned.

-Chris
- One of the changes I'd like to see soon is additional organization members so that we're less at risk of having the repo abandoned. @scompt, what do you think?
