### PR TITLE
Facebook crash fixs

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
@@ -275,7 +275,8 @@ static NSString *const kSHKFacebookExpiryDateKey=@"kSHKFacebookExpiryDate";
 
 - (void)dialog:(FBDialog *)dialog didFailWithError:(NSError *)error 
 {
-  [self sendDidFailWithError:error];
+  if (error.code != NSURLErrorCancelled)
+    [self sendDidFailWithError:error];
 }
 
 - (BOOL)dialog:(FBDialog*)dialog shouldOpenURLInExternalBrowser:(NSURL*)url


### PR DESCRIPTION
In "some conditions" _(can't exactly remember)_ I had this crash because `SHKFacebook` was released before `Facebook` finished its call.

Side note: the Facebook sharer is mostly obsolete thanks to `"message"` API field being deprecated by Facebook.
