### PR TITLE
iOS5 no longer returns presentingViewController when parentViewController is nil.

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -190,7 +190,11 @@ BOOL SHKinit;
 			self.isDismissingView = YES;
 			[[currentView parentViewController] dismissModalViewControllerAnimated:animated];
 		}
-		
+		else if([currentView presentingViewController] != nil)
+		{
+			self.isDismissingView = YES;
+			[[currentView presentingViewController] dismissModalViewControllerAnimated:animated];
+		}
 		else
 			self.currentView = nil;
 	}


### PR DESCRIPTION
In SHK.m, when hiding the ShareKit view controller we check to see if parentViewController is nil. If it is, we do not dismiss the modal view controller:

```
- (void)hideCurrentViewControllerAnimated:(BOOL)animated
{
  if (isDismissingView)
    return;

  if (currentView != nil)
  {
    // Dismiss the modal view
    if ([currentView parentViewController] != nil)
    {
      self.isDismissingView = YES;
      [[currentView parentViewController] dismissModalViewControllerAnimated:animated];
    }
    else
      self.currentView = nil;
    }
  }
}
```

Before iOS 5, if parentViewController was nil, the presenting view controller would be returned:
https://developer.apple.com/library/prerelease/ios/#documentation/UIKit/Reference/UIViewController_Class/Reference/Reference.html#//apple_ref/doc/uid/TP40006926-CH3-SW3

This is no longer true. I would suggest the following minor **else if** addition which seemed to fix the issue for me:

```
- (void)hideCurrentViewControllerAnimated:(BOOL)animated
{
  if (isDismissingView)
    return;

  if (currentView != nil)
  {
    // Dismiss the modal view
    if ([currentView parentViewController] != nil)
    {
      self.isDismissingView = YES;
      [[currentView parentViewController] dismissModalViewControllerAnimated:animated];
    }
    else if ([currentView presentingViewController] != nil)
    {
      self.isDismissingView = YES;
      [[currentView presentingViewController] dismissModalViewControllerAnimated:animated];
    }
    else
      self.currentView = nil;
    }
  }
}
```
