### PR TITLE
Feature/llvm compiler warnings

### DIFF
--- a/Classes/ShareKit/Configuration/SHKConfiguration.m
+++ b/Classes/ShareKit/Configuration/SHKConfiguration.m
@@ -114,7 +114,7 @@ static SHKConfiguration *sharedInstance = nil;
     return UINT_MAX;  // denotes an object that cannot be released
 }
 
-- (void)release {
+- (oneway void)release {
     //do nothing
 }
 

--- a/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
+++ b/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
@@ -595,6 +595,9 @@
 		case SHKShareTypeFile:
 			return (item.data != nil);
 			break;
+            
+        default:
+            break;
 	}
 	
 	return NO;

--- a/Classes/ShareKit/Sharers/Services/Facebook/FBConnect/FBDialog.m
+++ b/Classes/ShareKit/Sharers/Services/Facebook/FBConnect/FBDialog.m
@@ -37,7 +37,8 @@ static CGFloat kBorderWidth = 10;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-BOOL FBIsDeviceIPad() {
+BOOL FBIsDeviceIPad(void);
+BOOL FBIsDeviceIPad(void) {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 30200
   if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
     return YES;
@@ -178,7 +179,7 @@ BOOL FBIsDeviceIPad() {
   CGFloat width = floor(scale_factor * frame.size.width) - kPadding * 2;
   CGFloat height = floor(scale_factor * frame.size.height) - kPadding * 2;
 
-  _orientation = [UIApplication sharedApplication].statusBarOrientation;
+  _orientation = (UIDeviceOrientation)[UIApplication sharedApplication].statusBarOrientation;
   if (UIInterfaceOrientationIsLandscape(_orientation)) {
     self.frame = CGRectMake(kPadding, kPadding, height, width);
   } else {
@@ -448,7 +449,7 @@ BOOL FBIsDeviceIPad() {
 // UIDeviceOrientationDidChangeNotification
 
 - (void)deviceOrientationDidChange:(void*)object {
-  UIDeviceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+  UIDeviceOrientation orientation = (UIDeviceOrientation)[UIApplication sharedApplication].statusBarOrientation;
   if (!_showingKeyboard && [self shouldRotateToOrientation:orientation]) {
     [self updateWebOrientation];
 

--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -290,7 +290,7 @@
 - (BOOL)validateItem
 {
 	NSString *status = [item customValueForKey:@"status"];
-	return status != nil && status.length >= 0 && status.length <= 140;
+	return status != nil && status.length <= 140;
 }
 
 - (BOOL)send

--- a/Classes/ShareKit/UI/SHKFormFieldCell.m
+++ b/Classes/ShareKit/UI/SHKFormFieldCell.m
@@ -157,6 +157,9 @@
 		case SHKFormFieldTypeSwitch:
 			return toggle.on ? SHKFormFieldSwitchOn : SHKFormFieldSwitchOff;
 			break;
+            
+        default:
+            break;
 	}
 	
 	return textField.text;


### PR DESCRIPTION
I use (and on APPLE WWDC videos suggestion all of us should use) Apple LLVM compiler. It is more picky, and displays more warnings than gcc lvvm. Though they are minor, it makes no trouble to shut them off. And the changes make the code more clear, I think. At least, if someone new opens sharekit, she is not overwhelmed and disgusted by avalanche of warnings, like I was.

Some of the fixes are in fbconnect code. They are not fixed, even when they are long time in bug tracker. FBConnect is like sleeping this time, so I feel it makes no harm to repair it directly in our fork. If we once switch to the updated FBConnect (if there ever will be?) all should be transparent.
