### PR TITLE
SHKCustomActionSheet

### DIFF
--- a/Classes/ShareKit/Customize UI/SHKCustomActionSheet.h
+++ b/Classes/ShareKit/Customize UI/SHKCustomActionSheet.h
@@ -1,0 +1,34 @@
+//
+//  SHKCustomActionSheet.h
+//  ShareKit
+//
+//  Created by Vilem Kurz on 7.10.2011.
+
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+//
+
+#import "SHKActionSheet.h"
+
+@interface SHKCustomActionSheet : SHKActionSheet
+
+// See http://getsharekit.com/customize/ for additional information on customizing
+
+@end

--- a/Classes/ShareKit/Customize UI/SHKCustomActionSheet.m
+++ b/Classes/ShareKit/Customize UI/SHKCustomActionSheet.m
@@ -1,0 +1,34 @@
+//
+//  SHKCustomActionSheet.m
+//  ShareKit
+//
+//  Created by Vilem Kurz on 7.10.2011.
+
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+
+#import "SHKCustomActionSheet.h"
+
+@implementation SHKCustomActionSheet
+
+// See http://getsharekit.com/customize/ for additional information on customizing
+
+@end

--- a/Classes/ShareKit/UI/SHKActionSheet.m
+++ b/Classes/ShareKit/UI/SHKActionSheet.m
@@ -29,6 +29,7 @@
 #import "SHK.h"
 #import "SHKSharer.h"
 #import "SHKCustomShareMenu.h"
+#import "SHKCustomActionSheet.h"
 #import "SHKShareItemDelegate.h"
 
 #import <Foundation/NSObjCRuntime.h>
@@ -47,7 +48,7 @@
 
 + (SHKActionSheet *)actionSheetForType:(SHKShareType)type
 {
-	SHKActionSheet *as = [[SHKActionSheet alloc] initWithTitle:SHKLocalizedString(@"Share")
+	SHKCustomActionSheet *as = [[SHKCustomActionSheet alloc] initWithTitle:SHKLocalizedString(@"Share")
 													  delegate:nil
 											 cancelButtonTitle:nil
 										destructiveButtonTitle:nil


### PR DESCRIPTION
Customization enhancement. It originated from the need to add
- tap click sounds
- add service/action specific text message suffix/prefix

I can imagine it can be very useful other ways too. All of its brothers SHKCustom<UIElements> were already born...

This commit only adds the file and updates affected code. Next steps are to update sample project, and make some wiki record for all SHKCustom... stuff. I did not feel for that, as I only used this one, and do not know the history and purpose of others.

As this is an easy and lightweight addition, I suggest to add it to 2.0, together with wiki and sample update.
