### PR TITLE
Twitter image share crash fix

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -558,7 +558,6 @@
 	// NSLog([[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease]);
 	
 	if (ticket.didSucceed) {
-		[self sendDidFinish];
 		// Finished uploading Image, now need to posh the message and url in twitter
 		NSString *dataString = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
 		NSRange startingRange = [dataString rangeOfString:@"<url>" options:NSCaseInsensitiveSearch];


### PR DESCRIPTION
When shared image on twitter, request was sent, update status happened on twitter, but the app crashed immediately.

The reason is, that SHKTwitter sends image in two subsequent connections - 1. conn only sends image, 2. conn sends status update with image link. Each has callback method, and crash happened when calling delegate in second callback. The delegate was incorrectly released during the first callback.
