### PR TITLE
Fix facebook cancel affirmation

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.h
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.h
@@ -30,7 +30,9 @@
 #import "SHKSharer.h"
 #import "SHKFacebookForm.h"
 
-@interface SHKFacebook : SHKSharer <FBSessionDelegate, FBDialogDelegate, FBRequestDelegate>
+@interface SHKFacebook : SHKSharer <FBSessionDelegate, FBDialogDelegate, FBRequestDelegate> {
+    BOOL _dialogWasCancelled;
+}
 
 + (BOOL)handleOpenURL:(NSURL*)url;
 - (void)sendForm:(SHKFacebookForm *)form;

--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
@@ -31,6 +31,7 @@
 static NSString *const kSHKStoredItemKey=@"kSHKStoredItem";
 static NSString *const kSHKFacebookAccessTokenKey=@"kSHKFacebookAccessToken";
 static NSString *const kSHKFacebookExpiryDateKey=@"kSHKFacebookExpiryDate";
+static NSString *const kFBCancelURL = @"fbconnect://success#_=_";
 
 @interface SHKFacebook()
 
@@ -193,6 +194,9 @@ static NSString *const kSHKFacebookExpiryDateKey=@"kSHKFacebookExpiryDate";
 {			
  	if (![self validateItem])
 		return NO;
+    
+    _dialogWasCancelled = NO;
+    
 	NSMutableDictionary *params = [NSMutableDictionary dictionary];
 	NSString *actions = [NSString stringWithFormat:@"{\"name\":\"%@ %@\",\"link\":\"%@\"}",
 				SHKLocalizedString(@"Get"), SHKCONFIG(appName), SHKCONFIG(appURL)];
@@ -249,7 +253,12 @@ static NSString *const kSHKFacebookExpiryDateKey=@"kSHKFacebookExpiryDate";
 
 - (void)dialogDidComplete:(FBDialog *)dialog
 {
-  [self sendDidFinish];  
+    if(_dialogWasCancelled) {
+        [self sendDidCancel];
+    }
+    else {
+        [self sendDidFinish];
+    }
 }
 
 - (void)dialogDidNotComplete:(FBDialog *)dialog
@@ -266,6 +275,9 @@ static NSString *const kSHKFacebookExpiryDateKey=@"kSHKFacebookExpiryDate";
   {
     [SHKFacebook flushAccessToken];
     [self authorize];
+  }
+  if ([[url absoluteString] isEqualToString:kFBCancelURL]) {
+    _dialogWasCancelled = YES;      
   }
 }
 


### PR DESCRIPTION
Prevent a cancelled or closed Facebook dialog from showing the affirmative "Saved!" message.

It seems that anytime the Facebook Share dialog is closed or cancelled, the URL below is returned:

```
fbconnect://success#_=_
```

This update checks the URL response, and in the case of a match, calls sendDidCancel instead of sendDidFinish.

I haven't found any documentation on the URL format mentioned above from Facebook, so additional testing is welcome.
