### PR TITLE
Development

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKiOS5Twitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKiOS5Twitter.m
@@ -39,7 +39,7 @@
 }
 
 - (void)share {
-#ifndef _ARM_ARCH_6	    
+#ifdef _ARM_ARCH_7
     TWTweetComposeViewController *iOS5twitter = [[TWTweetComposeViewController alloc] init];
     
     [iOS5twitter addImage:self.item.image];    


### PR DESCRIPTION
Fixed the compatibility with old armv6 architecture .

The `TWTweetComposeViewController` is not available in armv6, thus you can't compile your project form armv6. 
If added a compile directive to allow compiling the project for arm6, by not including any code where `TWTweetComposeViewController` in the armv6 binary.
