### PR TITLE
Simplify modal view controller dismiss

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -188,6 +188,8 @@ BOOL SHKinit;
     
     self.isDismissingView = YES;
     [currentView dismissModalViewControllerAnimated:YES];
+    
+    self.currentView=nil;
 }
 
 - (void)showPendingView


### PR DESCRIPTION
no need to wrestle for whether the parent is in parentviewcontroller or presentingViewController
just send the dismiss to the presented view controller and it will forward appropriately:

from apple docs:
'If you call this method on the modal view controller itself, however, the modal view controller automatically forwards the message to its parent view controller.'

tested on iOS4 & 5
