### PR TITLE
Avoids hard linking NSJSONSerialization. Refs #147.

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -460,8 +460,9 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
         
         NSError *error = nil;
         NSMutableDictionary *userInfo;
-        if (NSClassFromString(@"NSJSONSerialization")) {
-            userInfo = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&error];
+        Class serializator = NSClassFromString(@"NSJSONSerialization");
+        if (serializator) {
+            userInfo = [serializator JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&error];
         } else {
             userInfo = [[JSONDecoder decoder] mutableObjectWithData:data error:&error];
         }    


### PR DESCRIPTION
Fixes startup linker crashes when running a sharekit program on a 3.x
device due to lack of NSJSONSerialization symbols.
