### PR TITLE
BUGFIX: SHKFormControllerLargeTextField text disappearing on iPad

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFormControllerLargeTextField.m
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFormControllerLargeTextField.m
@@ -89,7 +89,7 @@
 	if (UIKeyboardFrameEndUserInfoKey)
     {		
         [[notification.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] getValue:&keyboardFrame];		
-        if ([[UIDevice currentDevice] orientation] == UIDeviceOrientationPortrait || [[UIDevice currentDevice] orientation] == UIDeviceOrientationPortraitUpsideDown) 
+        if ([self interfaceOrientation] == UIDeviceOrientationPortrait || [self interfaceOrientation] == UIDeviceOrientationPortraitUpsideDown) 
         keyboardHeight = keyboardFrame.size.height;
         else
         keyboardHeight = keyboardFrame.size.width;


### PR DESCRIPTION
The problem was in UI orientation detection method - it always returned landscape orientation for iPad (maybe on simulator only) - thus wrongly sized UITextView and disappearing text. UIViewController's method works more predictably.

fixes #148 and #142
