### PR TITLE
BUGFIX: silenced remaining warnings

### DIFF
--- a/Classes/ShareKit/Core/Helpers/OAuth/OAAsynchronousDataFetcher.m
+++ b/Classes/ShareKit/Core/Helpers/OAuth/OAAsynchronousDataFetcher.m
@@ -98,7 +98,7 @@
 {
 	if (response)
 		[response release];
-	response = [aResponse retain];
+	response = (NSHTTPURLResponse *)[aResponse retain];
 	[responseData setLength:0];
 }
 

--- a/Classes/ShareKit/Core/Helpers/OAuth/OAMutableURLRequest.m
+++ b/Classes/ShareKit/Core/Helpers/OAuth/OAMutableURLRequest.m
@@ -199,9 +199,11 @@ signatureProvider:(id<OASignatureProviding, NSObject>)aProvider
 {
     CFUUIDRef theUUID = CFUUIDCreate(NULL);
     CFStringRef string = CFUUIDCreateString(NULL, theUUID);
-    NSMakeCollectable(theUUID);
+    [NSMakeCollectable(theUUID) autorelease];
+    if (nonce) {
+        CFRelease(nonce);
+    }
     nonce = (NSString *)string;
-	CFRelease(theUUID);
 }
 
 - (NSString *)_signatureBaseString

--- a/Classes/ShareKit/Core/Helpers/OAuth/OAServiceTicket.m
+++ b/Classes/ShareKit/Core/Helpers/OAuth/OAServiceTicket.m
@@ -36,11 +36,14 @@
 }
 
 - (id)initWithRequest:(OAMutableURLRequest *)aRequest response:(NSHTTPURLResponse *)aResponse data:(NSData *)aData didSucceed:(BOOL)success {
-    [super init];
-    request = aRequest;
-    response = aResponse;
-	data = aData;
-    didSucceed = success;
+    
+    self = [super init];
+    if (self) {
+        request = aRequest;
+        response = aResponse;
+        data = aData;
+        didSucceed = success;
+    }
     return self;
 }
 

--- a/Classes/ShareKit/Sharers/Services/Evernote/Helpers/edam/NoteStore.m
+++ b/Classes/ShareKit/Sharers/Services/Evernote/Helpers/edam/NoteStore.m
@@ -31587,9 +31587,11 @@
 
 - (id) initWithInProtocol: (id <TProtocol>) anInProtocol outProtocol: (id <TProtocol>) anOutProtocol
 {
-  [super init];
-  inProtocol = [anInProtocol retain];
-  outProtocol = [anOutProtocol retain];
+  self = [super init];
+  if (self) {
+      inProtocol = [anInProtocol retain];
+      outProtocol = [anOutProtocol retain];
+  }  
   return self;
 }
 

--- a/Classes/ShareKit/Sharers/Services/Evernote/Helpers/edam/UserStore.m
+++ b/Classes/ShareKit/Sharers/Services/Evernote/Helpers/edam/UserStore.m
@@ -2774,9 +2774,11 @@ static int16_t EDAMEDAM_VERSION_MINOR = 16;
 
 - (id) initWithInProtocol: (id <TProtocol>) anInProtocol outProtocol: (id <TProtocol>) anOutProtocol
 {
-  [super init];
-  inProtocol = [anInProtocol retain];
-  outProtocol = [anOutProtocol retain];
+  self = [super init];
+  if (self) {
+      inProtocol = [anInProtocol retain];
+      outProtocol = [anOutProtocol retain];
+  }
   return self;
 }
 

--- a/Classes/ShareKit/Sharers/Services/Flickr/LFHTTPRequest.m
+++ b/Classes/ShareKit/Sharers/Services/Flickr/LFHTTPRequest.m
@@ -585,7 +585,7 @@ void LFHRReadStreamClientCallBack(CFReadStreamRef stream, CFStreamEventType even
 		BOOL isReentrant = (_synchronousMessagePort != nil);
 		
 		if (!isReentrant) {
-			_synchronousMessagePort = [[NSPort port] retain];
+			_synchronousMessagePort = (NSMessagePort *)[[NSPort port] retain];
 			[currentRunLoop addPort:_synchronousMessagePort forMode:currentMode];
 		}
 		

--- a/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedInTextForm.m
+++ b/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedInTextForm.m
@@ -153,8 +153,10 @@
 - (void)updateCounter
 {
 	if (counter == nil)
-	{
-		self.counter = [[UILabel alloc] initWithFrame:CGRectZero];
+	{		
+        UILabel *aLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        self.counter = aLabel;
+        [aLabel release];
 		counter.backgroundColor = [UIColor clearColor];
 		counter.opaque = NO;
 		counter.font = [UIFont boldSystemFontOfSize:14];
@@ -165,8 +167,6 @@
 		
 		[self.view addSubview:counter];
 		[self layoutCounter];
-		
-		[counter release];
 	}
 	
 	int count = 700 - textView.text.length;

--- a/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakte.m
+++ b/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakte.m
@@ -139,12 +139,13 @@
 
 + (void)logout
 {
-	NSString *logout = @"http://api.vk.com/oauth/logout";
+	/*
+    NSString *logout = @"http://api.vk.com/oauth/logout";
 	
 	NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:logout] 
 																												 cachePolicy:NSURLRequestReloadIgnoringLocalCacheData 
 																										 timeoutInterval:60.0]; 
-	/*	NSData *responseData = [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:nil];
+		NSData *responseData = [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:nil];
 	if(responseData)
 	{
 		NSDictionary *dict = [[JSONDecoder decoder] parseJSONData:responseData];

--- a/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakteOAuthView.m
+++ b/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakteOAuthView.m
@@ -51,13 +51,14 @@
 	
 	if(!vkWebView)
 	{
-		self.vkWebView = [[UIWebView alloc] initWithFrame:self.view.bounds];
+		UIWebView *aWebView = [[UIWebView alloc] initWithFrame:self.view.bounds];
+        self.vkWebView = aWebView;
+        [aWebView release];
 		vkWebView.delegate = self;
 		vkWebView.scalesPageToFit = YES;
 		self.vkWebView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 		[self.view addSubview:vkWebView];
 	}
-
 	
 	if(!appID) 
 	{


### PR DESCRIPTION
FINALLY no more compile warnings in ShareKit. Also most of analyzer warnings are gone, with exception of Evernote's EDAM - we must accept them until they fix thrift generated code. I looked at their new api download, and these errors are still there.
