### PR TITLE
HOTFIX: SHKTextMessage crash

### DIFF
--- a/Classes/ShareKit/Sharers/Actions/Text Message/SHKTextMessage.m
+++ b/Classes/ShareKit/Sharers/Actions/Text Message/SHKTextMessage.m
@@ -167,7 +167,7 @@
 			break;
 	}
     [[SHK currentHelper] hideCurrentViewControllerAnimated:YES];
-    [self release]; //retained in [self sendText] method
+    [self autorelease]; //retained in [self sendText] method
 }
 
 


### PR DESCRIPTION
MFMessageComposeViewController does not retain its delegate, therefore SHKTextMessage must `[retain self]` temporarily, otherwise crash
