### PR TITLE
BUGFIX: SHKFlickr logout did not remove cookies

### DIFF
--- a/Classes/ShareKit/Core/Base Sharer Classes/SHKOAuthSharer.m
+++ b/Classes/ShareKit/Core/Base Sharer Classes/SHKOAuthSharer.m
@@ -28,6 +28,7 @@
 #import "SHKOAuthSharer.h"
 #import "SHKOAuthView.h"
 #import "OAuthConsumer.h"
+#import "NSHTTPCookieStorage+DeleteForURL.h"
 
 
 @implementation SHKOAuthSharer
@@ -298,13 +299,8 @@
 	SHKOAuthSharer *sharer = [[self alloc] init];
 	if (sharer.authorizeURL)
 	{
-		NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-		NSArray *cookies = [storage cookiesForURL:sharer.authorizeURL];
-		for (NSHTTPCookie *each in cookies) 
-		{
-			[storage deleteCookie:each];
-		}
-	}
+		[NSHTTPCookieStorage deleteCookiesForURL:sharer.authorizeURL];
+    }
 	[sharer release];
 }
 

--- a/Classes/ShareKit/Core/Categories/NSHTTPCookieStorage+DeleteForURL.h
+++ b/Classes/ShareKit/Core/Categories/NSHTTPCookieStorage+DeleteForURL.h
@@ -1,0 +1,15 @@
+//
+//  NSHTTPCookieStorage+DeleteForURL.h
+//  ShareKit
+//
+//  Created by Vilem Kurz on 22.1.2012.
+//  Copyright (c) 2012 Cocoa Miners. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSHTTPCookieStorage (DeleteForURL)
+
++ (void)deleteCookiesForURL:(NSURL *)url;
+
+@end

--- a/Classes/ShareKit/Core/Categories/NSHTTPCookieStorage+DeleteForURL.m
+++ b/Classes/ShareKit/Core/Categories/NSHTTPCookieStorage+DeleteForURL.m
@@ -1,0 +1,23 @@
+//
+//  NSHTTPCookieStorage+DeleteForURL.m
+//  ShareKit
+//
+//  Created by Vilem Kurz on 22.1.2012.
+//  Copyright (c) 2012 Cocoa Miners. All rights reserved.
+//
+
+#import "NSHTTPCookieStorage+DeleteForURL.h"
+
+@implementation NSHTTPCookieStorage (DeleteForURL)
+
++ (void)deleteCookiesForURL:(NSURL *)url {
+    
+    NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    NSArray *cookies = [storage cookiesForURL:url];
+    for (NSHTTPCookie *each in cookies) 
+    {
+        [storage deleteCookie:each];
+    }
+}
+
+@end

--- a/Classes/ShareKit/Sharers/Services/Flickr/SHKFlickr.m
+++ b/Classes/ShareKit/Sharers/Services/Flickr/SHKFlickr.m
@@ -27,6 +27,9 @@
 
 #import "SHKFlickr.h"
 #import "SHKConfiguration.h"
+#import "NSHTTPCookieStorage+DeleteForURL.h"
+
+NSString *kFlickrAuthenticationURL = @"http://flickr.com/services/auth/";
 
 NSString *kStoredAuthTokenKeyName = @"FlickrAuthToken";
 
@@ -87,7 +90,8 @@ NSString *kSetImagePropertiesStep = @"kSetImagePropertiesStep";
 
 + (void)logout
 {
-	[SHK removeAuthValueForKey:kStoredAuthTokenKeyName forSharer:[self sharerId]];
+    [SHK removeAuthValueForKey:kStoredAuthTokenKeyName forSharer:[self sharerId]];
+    [NSHTTPCookieStorage deleteCookiesForURL:[NSURL URLWithString:kFlickrAuthenticationURL]];
 }
 
 - (void)authorizationFormShow 

--- a/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2.m
+++ b/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2.m
@@ -32,6 +32,7 @@
 #import "SHKConfiguration.h"
 
 #import "NSString+URLEncoding.h"
+#import "NSHTTPCookieStorage+DeleteForURL.h"
 
 static NSString *authorizeURL = @"https://foursquare.com/oauth2/authenticate";
 static NSString *accessTokenKey = @"accessToken";
@@ -191,15 +192,8 @@ static NSString *accessTokenKey = @"accessToken";
 
 + (void)logout
 {
-	[self deleteStoredAccessToken];
-	
-	// Clear cookies 
-    NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSArray *cookies = [storage cookiesForURL:[NSURL URLWithString:authorizeURL]];
-    for (NSHTTPCookie *each in cookies) 
-    {
-        [storage deleteCookie:each];
-    }
+	[self deleteStoredAccessToken];	
+    [NSHTTPCookieStorage deleteCookiesForURL:[NSURL URLWithString:authorizeURL]];
 }
 
 #pragma mark -

--- a/ShareKit.xcodeproj/project.pbxproj
+++ b/ShareKit.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		43D1DEF011D5CDD200550D75 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43D1DEEF11D5CDD200550D75 /* SystemConfiguration.framework */; };
 		43EF406E11D3FFF800B1F700 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43EF406D11D3FFF800B1F700 /* Security.framework */; };
 		7A2B025614A342D800E68A4C /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A2B025514A342D800E68A4C /* CFNetwork.framework */; };
+		7A333EE514CC5B9D0060900C /* NSHTTPCookieStorage+DeleteForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A333EE414CC5B9D0060900C /* NSHTTPCookieStorage+DeleteForURL.m */; };
 		7A36F42714B2021100372747 /* SHKSharerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A36F42614B2021100372747 /* SHKSharerDelegate.m */; };
 		7A3C61EE147520B700C47D14 /* Twitter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A3C61ED147520B700C47D14 /* Twitter.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		7A89681D14C80F9900DB07AF /* SHKFormControllerLargeTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AF78BB214B71FD8008ACA5D /* SHKFormControllerLargeTextField.m */; };
@@ -300,6 +301,8 @@
 		43D1DEEF11D5CDD200550D75 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		43EF406D11D3FFF800B1F700 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		7A2B025514A342D800E68A4C /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		7A333EE314CC5B9D0060900C /* NSHTTPCookieStorage+DeleteForURL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSHTTPCookieStorage+DeleteForURL.h"; sourceTree = "<group>"; };
+		7A333EE414CC5B9D0060900C /* NSHTTPCookieStorage+DeleteForURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSHTTPCookieStorage+DeleteForURL.m"; sourceTree = "<group>"; };
 		7A36F42514B2021100372747 /* SHKSharerDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SHKSharerDelegate.h; sourceTree = "<group>"; };
 		7A36F42614B2021100372747 /* SHKSharerDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SHKSharerDelegate.m; sourceTree = "<group>"; };
 		7A3C61ED147520B700C47D14 /* Twitter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Twitter.framework; path = System/Library/Frameworks/Twitter.framework; sourceTree = SDKROOT; };
@@ -658,6 +661,8 @@
 				4379F2E91291AE5700D2A41E /* NSData+md5.m */,
 				43A5367911DBE3B9004A1712 /* UIWebView+SHK.h */,
 				43A5367A11DBE3B9004A1712 /* UIWebView+SHK.m */,
+				7A333EE314CC5B9D0060900C /* NSHTTPCookieStorage+DeleteForURL.h */,
+				7A333EE414CC5B9D0060900C /* NSHTTPCookieStorage+DeleteForURL.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -1269,11 +1274,11 @@
 				FA5AA3BE149625460064DB24 /* SHKVkontakte.m in Sources */,
 				7A36F42714B2021100372747 /* SHKSharerDelegate.m in Sources */,
 				7A89681D14C80F9900DB07AF /* SHKFormControllerLargeTextField.m in Sources */,
-				7A0861D914A36E5A00FF509F /* SHKFormControllerLargeTextField.m in Sources */,
 				A57772B414BA0748003FC744 /* SSKeychain.m in Sources */,
 				A57772BC14BA1900003FC744 /* ObjectiveFlickr.m in Sources */,
 				A57772BD14BA1900003FC744 /* OFUtilities.m in Sources */,
 				A57772BE14BA1900003FC744 /* OFXMLMapper.m in Sources */,
+				7A333EE514CC5B9D0060900C /* NSHTTPCookieStorage+DeleteForURL.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Also refactored cookies removal as a category on NSHTTPCookieStorage, so that the same code is not duplicated throughout SHK. Fix for #114
