### PR TITLE
remove validate item in send

### DIFF
--- a/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
+++ b/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
@@ -287,10 +287,6 @@
 
 - (void)share
 {
-    if (![self validateItem]) {
-        return; //otherwise self would stay retained forever. 
-    }
-
 	// isAuthorized - If service requires login and details have not been saved, present login dialog	
 	if (![self authorize])
 		self.pendingAction = SHKPendingShare;


### PR DESCRIPTION
This call to validate item prevents items that can be invalid at the start, then become valid in show from working. Vilem, the author of the line says it is no longer needed.
