### PR TITLE
Fix for "Operation timed out" seen when running 'git submodule init'+'git submodule update'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "Submodules/facebook-ios-sdk"]
 	path = Submodules/facebook-ios-sdk
-	url = git://github.com/ShareKit/facebook-ios-sdk.git
+	url = https://github.com/ShareKit/facebook-ios-sdk.git
 [submodule "JSONKit"]
 	path = Submodules/JSONKit
-	url = git://github.com/johnezang/JSONKit.git
+	url = https://github.com/johnezang/JSONKit.git
 [submodule "Submodules/sskeychain"]
 	path = Submodules/sskeychain
-	url = git://github.com/samsoffes/sskeychain.git
+	url = https://github.com/samsoffes/sskeychain.git
 [submodule "Submodules/objectiveflickr"]
 	path = Submodules/objectiveflickr
-	url = git://github.com/lukhnos/objectiveflickr.git
+	url = https://github.com/lukhnos/objectiveflickr.git


### PR DESCRIPTION
Fix for issue where submodules fail to download from behind certain corporate firewalls by changing url protocol from 'git' to 'https'. See http://stackoverflow.com/questions/3140715/why-does-git-push-fails-with-operation-timed-out.
