### PR TITLE
SHKCopy should support text

### DIFF
--- a/Classes/ShareKit/Sharers/Actions/Copy/SHKCopy.m
+++ b/Classes/ShareKit/Sharers/Actions/Copy/SHKCopy.m
@@ -38,6 +38,11 @@
 	return SHKLocalizedString(@"Copy");
 }
 
++ (BOOL)canShareText
+{
+	return YES;
+}
+
 + (BOOL)canShareURL
 {
 	return YES;


### PR DESCRIPTION
For now, it will just copy the item.text.

Original pull: https://github.com/ShareKit/ShareKit/pull/218.
