### PR TITLE
Fixed a bug in which the SHKActionSheet would display the More on Cancel

### DIFF
--- a/Classes/ShareKit/UI/SHKActionSheet.m
+++ b/Classes/ShareKit/UI/SHKActionSheet.m
@@ -90,9 +90,14 @@
 }
 
 - (void)dismissWithClickedButtonIndex:(NSInteger)buttonIndex animated:(BOOL)animated
-{
+{    
     NSInteger numberOfSharers = (NSInteger) [sharers count];
 
+    if (buttonIndex == self.cancelButtonIndex) {
+        [super dismissWithClickedButtonIndex:buttonIndex animated:animated];
+        return;
+    }
+    
 	// Sharers
 	if (buttonIndex >= 0 && buttonIndex < numberOfSharers)
 	{


### PR DESCRIPTION
In my case, I was customizing SHKActionSheet with a subclass and wondering why my cancel button wasn't working.

This commit safely handles the Cancel button index before any other buttons, that way cancel never has any effect other than canceling.
