### PR TITLE
Fix build issues on case-sensitive file systems.

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Evernote/Helpers/edam/NoteStore.h
+++ b/Classes/ShareKit/Sharers/Services/Evernote/Helpers/edam/NoteStore.h
@@ -14,7 +14,7 @@
 #import "UserStore.h"
 #import "Types.h"
 #import "Errors.h"
-#import "Limits.h"
+#import <limits.h>
 
 @interface EDAMSyncState : NSObject <NSCoding> {
   EDAMTimestamp __currentTime;

--- a/Classes/ShareKit/Sharers/Services/Evernote/Helpers/edam/NoteStore.m
+++ b/Classes/ShareKit/Sharers/Services/Evernote/Helpers/edam/NoteStore.m
@@ -14,7 +14,7 @@
 #import "UserStore.h"
 #import "Types.h"
 #import "Errors.h"
-#import "Limits.h"
+#import <limits.h>
 
 #import "NoteStore.h"
 

--- a/ShareKit.xcodeproj/project.pbxproj
+++ b/ShareKit.xcodeproj/project.pbxproj
@@ -979,7 +979,7 @@
 				7AC22D2514580A2000126878 /* FBDialog.m */,
 			);
 			name = FBConnect;
-			path = "../../../../../submodules/facebook-ios-sdk/src";
+			path = "../../../../../Submodules/facebook-ios-sdk/src";
 			sourceTree = "<group>";
 		};
 		7AC22D1C14580A2000126878 /* JSON */ = {


### PR DESCRIPTION
I run case-sensitive file systems whenever possible, as they are less permissive and catch case matching errors. The Facebook SDK path had 'Submodules' as 'submodules', and NoteStore used Limits.h twice. Also, since limits.h is in a system framework, it should be <limits.h>--as it is elsewhere in the project--rather than "Limits.h".
