### PR TITLE
Consistently use item.title if available and fall back to item.text in Twitter sharing.

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -331,7 +331,7 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
 {	
 	if (![SHK connected])
 	{
-		[item setCustomValue:[NSString stringWithFormat:@"%@ %@", item.title, [item.URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] forKey:@"status"];
+		[item setCustomValue:[NSString stringWithFormat:@"%@ %@", item.title ? item.title : item.text, [item.URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] forKey:@"status"];
 		return YES;
 	}
 	
@@ -366,7 +366,7 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
 						   cancelButtonTitle:SHKLocalizedString(@"Continue")
 						   otherButtonTitles:nil] autorelease] show];
 		
-		[item setCustomValue:[NSString stringWithFormat:@"%@ %@", item.text ? item.text : item.title, [item.URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] forKey:@"status"];
+		[item setCustomValue:[NSString stringWithFormat:@"%@ %@", item.title ? item.title : item.text, [item.URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] forKey:@"status"];
 	}
 	
 	else
@@ -375,7 +375,7 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
 		if ([result isEqualToString:@"ALREADY_A_BITLY_LINK"])
 			result = [item.URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 		
-		[item setCustomValue:[NSString stringWithFormat:@"%@ %@", item.text ? item.text : item.title, result] forKey:@"status"];
+		[item setCustomValue:[NSString stringWithFormat:@"%@ %@", item.title ? item.title : item.text, result] forKey:@"status"];
 	}
 	
 	[super share];


### PR DESCRIPTION
Consistently use item.title if available and fall back to item.text in Twitter sharing, regardless of if there's an Internet connection or not.

Rationale for this change is: Factory method +[SHKItem URL:title:] takes in title, not text. Why use text if URL and title are the default options given to ShareKit user. Also, Twitter has a limitation of 140 characters, so title is probably the more fitting thing to share than the (body) text of an article, for example. Thus: A) get rid of inconsistency based on connectivity and B) always use the (probably shorter) title, because tweet length is so limited.
