### PR TITLE
Made Twitter URL shortening optional

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -329,18 +329,22 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
 
 - (BOOL)shortenURL
 {	
-	if (![SHK connected])
+	NSString *bitLyLogin = SHKCONFIG(bitLyLogin);
+	NSString *bitLyKey = SHKCONFIG(bitLyKey);
+	BOOL bitLyConfigured = [bitLyLogin length] > 0 && [bitLyKey length] > 0;
+	
+	if (bitLyConfigured == NO || ![SHK connected])
 	{
 		[item setCustomValue:[NSString stringWithFormat:@"%@ %@", item.title, [item.URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] forKey:@"status"];
-		return YES;
+		return bitLyConfigured;
 	}
 	
 	if (!quiet)
 		[[SHKActivityIndicator currentIndicator] displayActivity:SHKLocalizedString(@"Shortening URL...")];
     
 	self.request = [[[SHKRequest alloc] initWithURL:[NSURL URLWithString:[NSMutableString stringWithFormat:@"http://api.bit.ly/v3/shorten?login=%@&apikey=%@&longUrl=%@&format=txt",
-																		 SHKCONFIG(bitLyLogin),
-																		  SHKCONFIG(bitLyKey),																		  
+																		  bitLyLogin,
+																		  bitLyKey,																		  
 																		  SHKEncodeURL(item.URL)
 																		  ]]
 											 params:nil


### PR DESCRIPTION
Made Twitter URL shortening optional: leave out bit.ly configuration and URLs won't be shortened (affects iOS4 Twitter, iOS5 has system Twitter).

This is useful when sharing links for a website that already has short URLs, and the actual URLs are what we want to be seen in Facebook or Twitter when users share the URLs.
