### PR TITLE
Made Twitter URL shortening optional

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -336,7 +336,7 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
 	if (bitLyConfigured == NO || ![SHK connected])
 	{
 		[item setCustomValue:[NSString stringWithFormat:@"%@ %@", item.title, [item.URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] forKey:@"status"];
-		return bitLyConfigured;
+		return YES;
 	}
 	
 	if (!quiet)


### PR DESCRIPTION
Made Twitter URL shortening optional: leave out bit.ly configuration and URLs won't be shortened (affects iOS4 Twitter, iOS5 has system Twitter).

BTW: Sorry about the number of pull requests, I'm just learning Git and GitHub. I hope the code changes themselves are good.
