### PR TITLE
Added a couple more characters to SHKEncode

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -664,6 +664,8 @@ NSString * SHKEncode(NSString * value)
 	string = [string stringByReplacingOccurrencesOfString:@"&" withString:@"%26"];
     string = [string stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];
     string = [string stringByReplacingOccurrencesOfString:@"#" withString:@"%23"];
+    string = [string stringByReplacingOccurrencesOfString:@"!" withString:@"%21"];
+    string = [string stringByReplacingOccurrencesOfString:@"@" withString:@"%40"];
 	
 	return string;	
 }


### PR DESCRIPTION
Using ShareKit, Pinboard wasn't accepting my credentials. This turned out to be because my password includes a couple characters that don't get percent encoded by the current `SHKEncode` implementation, so I added them.
