### PR TITLE
SHKShareMenu.m: fix one crash and one bug

### DIFF
--- a/Classes/ShareKit/UI/SHKShareMenu.m
+++ b/Classes/ShareKit/UI/SHKShareMenu.m
@@ -98,7 +98,7 @@
 	// If not editing, hide them
 	
     if([[NSUserDefaults standardUserDefaults] objectForKey:@"SHKExcluded"] != nil){
-        [self setExclusions:[NSArray arrayWithArray:[[NSUserDefaults standardUserDefaults] objectForKey:@"SHKExcluded"]]];
+        [self setExclusions:[NSMutableArray arrayWithArray:[[NSUserDefaults standardUserDefaults] objectForKey:@"SHKExcluded"]]];
     }else{
         [self setExclusions:[NSMutableArray arrayWithCapacity:0]];
     }
@@ -258,7 +258,7 @@
 		[toggle setOn:newOn animated:YES];
 		
 		if (newOn) {
-			[exclusions removeObjectIdenticalTo:[rowData objectForKey:@"className"]];
+			[exclusions removeObject:[rowData objectForKey:@"className"]];
             
 		} else {
 			NSString *sharerId = [rowData objectForKey:@"className"];


### PR DESCRIPTION
If exclusions were set in the user defaults and a user subsequently
tried to change the exclusions again, the app would crash due to the
array not being mutable.
Additionally, removing exclusions was not always possible because
removeObjectIdenticalTo: was used instead of removeObject:. The formes
compares addresses which might be fine during the same session (did not
check this one completely), but after starting the app again the
addresses are very likely to differ.
