### PR TITLE
Don't use sharers which are defined in defaultFavoriteXXXSharers but not in SHKSharers.plist

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -194,7 +194,8 @@ BOOL SHKinit;
 		
 		if ([nextResponder isKindOfClass:[UIViewController class]])
 			result = nextResponder;
-		
+		else if ([topWindow respondsToSelector:@selector(rootViewController)] && topWindow.rootViewController != nil)
+            result = topWindow.rootViewController;
 		else
 			NSAssert(NO, @"ShareKit: Could not find a root view controller.  You can assign one manually by calling [[SHK currentHelper] setRootViewController:YOURROOTVIEWCONTROLLER].");
 	}


### PR DESCRIPTION
This allows to exclude sharers by removing them from the SHKSharers.plist. Also it avoids the situation where SHKSharers.plist contains a subclass of a specific sharer but defaultFavoriteXXXSharers returns the base sharer class.
