### PR TITLE
Use rootViewController property of UIWindow to find rootViewController

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -194,7 +194,8 @@ BOOL SHKinit;
 		
 		if ([nextResponder isKindOfClass:[UIViewController class]])
 			result = nextResponder;
-		
+		else if ([topWindow respondsToSelector:@selector(rootViewController)] && topWindow.rootViewController != nil)
+            result = topWindow.rootViewController;
 		else
 			NSAssert(NO, @"ShareKit: Could not find a root view controller.  You can assign one manually by calling [[SHK currentHelper] setRootViewController:YOURROOTVIEWCONTROLLER].");
 	}


### PR DESCRIPTION
Use rootViewController property of UIWindow to find rootViewController in case the first subview of UIWindow is not the view of a UIViewController.
