### PR TITLE
BUGFIX: User can edit title in Facebook image share. Fix for #225

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
@@ -386,7 +386,7 @@ static NSString *const kSHKFacebookUserInfo =@"kSHKFacebookUserInfo";
 
 - (void)show
 {
-    if (item.shareType == SHKShareTypeText)        
+    if (item.shareType == SHKShareTypeText || item.shareType == SHKShareTypeImage)        
     {
         [self showFacebookForm];
     }
@@ -399,7 +399,17 @@ static NSString *const kSHKFacebookUserInfo =@"kSHKFacebookUserInfo";
 - (void)showFacebookForm
 {
  	SHKFormControllerLargeTextField *rootView = [[SHKFormControllerLargeTextField alloc] initWithNibName:nil bundle:nil delegate:self];  
- 	rootView.text = item.text;
+ 	
+    switch (self.item.shareType) {
+        case SHKShareTypeText:
+            rootView.text = item.text;
+            break;
+        case SHKShareTypeImage:
+            rootView.image = item.image;
+            rootView.text = item.title;            
+        default:
+            break;
+    }    
     
     self.navigationBar.tintColor = SHKCONFIG_WITH_ARGUMENT(barTintForView:,self);
  	[self pushViewController:rootView animated:NO];
@@ -410,7 +420,16 @@ static NSString *const kSHKFacebookUserInfo =@"kSHKFacebookUserInfo";
 
 - (void)sendForm:(SHKFormControllerLargeTextField *)form
 {  
- 	self.item.text = form.textView.text;
+ 	switch (self.item.shareType) {
+        case SHKShareTypeText:
+            self.item.text = form.textView.text;
+            break;
+        case SHKShareTypeImage:
+            self.item.title = form.textView.text;
+        default:
+            break;
+    }    
+    
  	[self tryToSend];
 }  
 

--- a/Classes/ShareKit/UI/SHKFormControllerLargeTextField.m
+++ b/Classes/ShareKit/UI/SHKFormControllerLargeTextField.m
@@ -182,10 +182,18 @@
 		[self layoutCounter];
 	}
 	
-	NSInteger count = (self.image?(self.maxTextLength - self.imageTextLength):self.maxTextLength) - self.textView.text.length;
-	counter.text = [NSString stringWithFormat:@"%@%i", self.image ? [NSString stringWithFormat:@"Image %@ ",count>0?@"+":@""]:@"", count];
-	
-	if (count >= 0) {
+	NSString *count;
+    NSInteger countNumber = 0;
+    
+    if (self.maxTextLength) {
+        countNumber = (self.image?(self.maxTextLength - self.imageTextLength):self.maxTextLength) - self.textView.text.length;
+        count = [NSString stringWithFormat:@"%i", countNumber];
+    } else {
+        count = @"";
+    }
+    counter.text = [NSString stringWithFormat:@"%@%@", self.image ? [NSString stringWithFormat:@"Image %@ ",countNumber>0?@"+":@""]:@"", count];
+ 	
+	if (countNumber >= 0) {
 		
 		self.counter.textColor = [UIColor blackColor];        
 		if (self.textView.text.length) self.navigationItem.rightBarButtonItem.enabled = YES; 


### PR DESCRIPTION
touches also #237. If user chooses to share image on Facebook, LargeTextFieldController is presented, like in Facebook text sharing. Was sharing silently.
