### PR TITLE
Rotation blocked by default

### DIFF
--- a/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2VenuesForm.m
+++ b/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2VenuesForm.m
@@ -148,7 +148,7 @@
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
     // Return YES for supported orientations
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+    return YES;
 }
 
 #pragma mark - Table view data source

--- a/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakteOAuthView.m
+++ b/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakteOAuthView.m
@@ -83,7 +83,7 @@
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
-	return (interfaceOrientation == UIInterfaceOrientationPortrait);
+    return YES;
 }
 
 #pragma mark - Web View Delegate


### PR DESCRIPTION
If all the networks were included, those 2 were blocking the rotation behavior on the iOS5. 

Haven't checked for the iOS 4.x versions.
