### PR TITLE
Fix problem where activity indicator spinner and text are both visible

### DIFF
--- a/Classes/ShareKit/UI/SHKActivityIndicator.h
+++ b/Classes/ShareKit/UI/SHKActivityIndicator.h
@@ -54,6 +54,7 @@
 - (void)setCenterMessage:(NSString *)message;
 - (void)setSubMessage:(NSString *)message;
 - (void)showSpinner;
+- (void)hideSpinner;
 - (void)setProperRotation;
 - (void)setProperRotation:(BOOL)animated;
 

--- a/Classes/ShareKit/UI/SHKActivityIndicator.m
+++ b/Classes/ShareKit/UI/SHKActivityIndicator.m
@@ -191,7 +191,7 @@ static SHKActivityIndicator *_currentIndicator = nil;
 		}
 		
 		centerMessageLabel.text = message;
-		[spinner removeFromSuperview];
+		[self hideSpinner];
 	}
 }
 
@@ -238,6 +238,11 @@ static SHKActivityIndicator *_currentIndicator = nil;
 	
 	[self addSubview:spinner];
 	[spinner startAnimating];
+}
+
+- (void)hideSpinner
+{
+	[spinner removeFromSuperview]
 }
 
 #pragma mark -


### PR DESCRIPTION
When text for SHKActivityIndicator is set, the spinner should disappear if it is visible. This change removes the spinner from the view hierarchy when the center message label text is set.
