### PR TITLE
Fix /me request for FB users w/o username

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
@@ -357,10 +357,9 @@ static NSString *const kSHKFacebookUserInfo =@"kSHKFacebookUserInfo";
   [self sendDidStart];
 }
 
-- (void)request:(FBRequest *)request didLoad:(id)result
+- (void)request:(FBRequest *)fbRequest didLoad:(id)result
 {   
-    if ([result objectForKey:@"username"]){
-        
+    if ([fbRequest.url hasSuffix:@"/me"] && [result objectForKey:@"id"]) {
         [result convertNSNullsToEmptyStrings];
         [[NSUserDefaults standardUserDefaults] setObject:result forKey:kSHKFacebookUserInfo];
     }     


### PR DESCRIPTION
If a Facebook user never set up a username, the [SHKFacebook getUserInfo] call will never load user info into user defaults, because the request:didLoad: delegate method checks for the existence of 'username' in the result.
