### PR TITLE
Encode ampersands in URLs when posting to Evernote

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Evernote/SHKEvernote.m
+++ b/Classes/ShareKit/Sharers/Services/Evernote/SHKEvernote.m
@@ -232,7 +232,7 @@
       NSString * strURL = [item.URL absoluteString];
 
       // Evernote doesn't accept unenencoded ampersands
-      strURL = [strURL stringByReplacingOccurrencesOfString:@"&" withString:@"&amp;"];
+	  strURL = SHKEncode(strURL);
             
       if(strURL.length>0) {
         if(item.title.length>0)


### PR DESCRIPTION
Evernotes API ignores URL posts with unencoded ampersands. Ensure that URL posts to Evernote encode "&" as "&amp;amp;".
