### PR TITLE
Rename 'Read It Later' to 'Pocket'

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Read It Later/SHKReadItLater.m
+++ b/Classes/ShareKit/Sharers/Services/Read It Later/SHKReadItLater.m
@@ -47,7 +47,7 @@
 
 + (NSString *)sharerTitle
 {
-	return @"Read It Later";
+	return @"Pocket";
 }
 
 + (BOOL)canShareURL


### PR DESCRIPTION
Read It Later has been [renamed](http://getpocket.com/blog/2012/04/introducing-the-all-new-read-it-later-now-called-pocket/) to Pocket. This pull request renames the service in the GUI. All other instances of RIL throughout the code remain.

Interestingly, in the email they sent out announcing the change, they described how to make this change if you're using ShareKit:

```

ShareKit : How to Rename Read It Later to Pocket

Updating ShareKit to change Read It Later’s name to Pocket is easy. You just have to modify one line.

1. Open the SHKReadItLater.m file (under ShareKit/Sharers/Services/Read It Later)
2. Locate the + (NSString *)sharerTitle method (line 39)
3. Change the string @”Read It Later” to @”Pocket”

You’re all set!
```
