### PR TITLE
Update "Sent from This App" message to "Via this App" message

### DIFF
--- a/Classes/ShareKit/Sharers/Actions/Email/SHKMail.m
+++ b/Classes/ShareKit/Sharers/Actions/Email/SHKMail.m
@@ -163,7 +163,7 @@
 		if ([SHKCONFIG(sharedWithSignature) boolValue])
 		{
 			body = [body stringByAppendingString:@"<br/><br/>"];
-			body = [body stringByAppendingString:SHKLocalizedString(@"Sent from %@", SHKCONFIG(appName))];
+			body = [body stringByAppendingString:SHKLocalizedString(@"Via %@", SHKCONFIG(appName))];
 		}
 		
 		// save changes to body


### PR DESCRIPTION
The mailer already appends "Send from iPhone/iPad". So having Send from this app, then Send from iPad again feels weird. it's better to say Via this app, send from iPhone. 
