### PR TITLE
NEW FEATURE: Added possibility to mark URL Share content type. Implement...

### DIFF
--- a/Classes/Example/ExampleShareLink.m
+++ b/Classes/Example/ExampleShareLink.m
@@ -55,7 +55,8 @@
 
 - (void)share
 {
-	SHKItem *item = [SHKItem URL:webView.request.URL title:[webView pageTitle]];
+	SHKItem *item = [SHKItem URL:webView.request.URL title:[webView pageTitle] contentType:(SHKURLContentTypeWebpage)];
+    //SHKItem *item = [SHKItem URL:[NSURL URLWithString:@"http://www.youtube.com/watch?v=3t8MeE8Ik4Y"] title:@"Big bang" contentType:SHKURLContentTypeVideo];
     //item.facebookURLSharePictureURI = @"http://www.state.gov/cms_images/india_tajmahal_2003_06_252.jpg";
     //item.facebookURLShareDescription = @"description text";
     item.mailToRecipients = [NSArray arrayWithObjects:@"frodo@middle-earth.me", @"gandalf@middle-earth.me", nil];

--- a/Classes/ShareKit/Configuration/SHKConfiguration.m
+++ b/Classes/ShareKit/Configuration/SHKConfiguration.m
@@ -63,7 +63,7 @@ static SHKConfiguration *sharedInstance = nil;
 		}
 	}
 
-	SHKLog(@"Didn't find a configuration value for %@.", selector);
+	//SHKLog(@"Configuration value is nil or not found for %@.", selector);
 	return nil;
 }
 

--- a/Classes/ShareKit/Core/SHKItem.h
+++ b/Classes/ShareKit/Core/SHKItem.h
@@ -37,6 +37,14 @@ typedef enum
     SHKShareTypeUserInfo
 } SHKShareType;
 
+typedef enum 
+{
+    SHKURLContentTypeUndefined,
+    SHKURLContentTypeWebpage,
+    SHKURLContentTypeAudio,
+    SHKURLContentTypeVideo,
+} SHKURLContentType;
+
 
 @interface SHKItem : NSObject
 {	
@@ -61,6 +69,7 @@ typedef enum
 @property (nonatomic)			SHKShareType shareType;
 
 @property (nonatomic, retain)	NSURL *URL;
+@property (nonatomic) SHKURLContentType URLContentType;
 
 @property (nonatomic, retain)	UIImage *image;
 
@@ -76,7 +85,11 @@ typedef enum
 
 /* always use these for SHKItem object creation, as they implicitly set appropriate SHKShareType. Items without SHKShareType will not be shared! */
 
-+ (id)URL:(NSURL *)url title:(NSString *)title;
++ (id)URL:(NSURL *)url title:(NSString *)title __attribute__((deprecated));//use the method with content type instead
+
+//Some sharers might present audio and video urls in enhanced way - e.g with media player (see Tumblr sharer). Other sharers share same way they used to, regardless of what type is specified.
++ (id)URL:(NSURL *)url title:(NSString *)title contentType:(SHKURLContentType)type;
+
 + (id)image:(UIImage *)image title:(NSString *)title;
 + (id)text:(NSString *)text;
 + (id)file:(NSData *)data filename:(NSString *)filename mimeType:(NSString *)mimeType title:(NSString *)title;

--- a/Classes/ShareKit/Core/SHKItem.m
+++ b/Classes/ShareKit/Core/SHKItem.m
@@ -42,7 +42,7 @@
 @implementation SHKItem
 
 @synthesize shareType;
-@synthesize URL, image, title, text, tags, data, mimeType, filename;
+@synthesize URL, URLContentType, image, title, text, tags, data, mimeType, filename;
 @synthesize custom;
 @synthesize printOutputType;
 @synthesize mailBody, mailJPGQuality, mailToRecipients, isMailHTML, mailShareWithAppSignature;
@@ -99,17 +99,24 @@
 
 + (id)URL:(NSURL *)url
 {
-	return [self URL:url title:nil];
+	return [self URL:url title:nil contentType:SHKURLContentTypeWebpage];
 }
 
 + (id)URL:(NSURL *)url title:(NSString *)title
 {
-	SHKItem *item = [[self alloc] init];
+	return [self URL:url title:title contentType:SHKURLContentTypeWebpage];
+}
+
++ (id)URL:(NSURL *)url title:(NSString *)title contentType:(SHKURLContentType)type {
+    
+    SHKItem *item = [[self alloc] init];
 	item.shareType = SHKShareTypeURL;
 	item.URL = url;
 	item.title = title;
+    item.URLContentType = type;
 	
 	return [item autorelease];
+    
 }
 
 + (id)image:(UIImage *)image

--- a/Classes/ShareKit/Sharers/Services/Tumblr/SHKTumblr.m
+++ b/Classes/ShareKit/Sharers/Services/Tumblr/SHKTumblr.m
@@ -211,11 +211,33 @@ static NSString * const kStoredAuthPasswordKeyName = @"password";
             
             //set type param
             if ([item shareType] == SHKShareTypeURL){
-                [params appendString:@"&type=link"];
-                [params appendFormat:@"&url=%@",SHKEncodeURL([item URL])];
-                if([item title]){
-                    [params appendFormat:@"&name=%@", SHKEncode([item title])];   
+                
+                switch (item.URLContentType) {
+                        
+                    case SHKURLContentTypeVideo:
+                        [params appendString:@"&type=video"];
+                        [params appendFormat:@"&embed=%@", SHKEncodeURL([item URL])];
+                        if([item title]){
+                            [params appendFormat:@"&caption=%@", SHKEncode([item title])];
+                        }
+                        break;
+                    case SHKURLContentTypeAudio:
+                        [params appendString:@"&type=audio"];
+                        [params appendFormat:@"&externally-hosted-url=%@", SHKEncodeURL([item URL])];
+                        if([item title]){
+                            [params appendFormat:@"&caption=%@", SHKEncode([item title])];
+                        }
+                        break;
+                    case SHKURLContentTypeWebpage:
+                    default:
+                        [params appendString:@"&type=link"];
+                        [params appendFormat:@"&url=%@",SHKEncodeURL([item URL])];
+                        if([item title]){
+                            [params appendFormat:@"&name=%@", SHKEncode([item title])];
+                        }
+                        break;
                 }
+                
             }else{
                 [params appendString:@"&type=regular"];
                 if([item title]){
@@ -337,10 +359,12 @@ static NSString * const kStoredAuthPasswordKeyName = @"password";
 		}
         else if (aRequest.response.statusCode == 500) {
             [self sendDidFailWithError:[SHK error:SHKLocalizedString(@"The service encountered an error. Please try again later.")]];
+            SHKLog(@"error response: %@", [aRequest description]);
             return;
         }
         
 		[self sendDidFailWithError:[SHK error:SHKLocalizedString(@"There was an error sending your post to Tumblr.")]];
+        SHKLog(@"error response: %@", [aRequest description]);
 		return;
 	}
     


### PR DESCRIPTION
...ed in Tumblr sharer.

This enables sharers to display multimedia content in an enhanced way using players etc. without bloating SHKItem with too many sharer specific instructions.
Also enabled some SHKLog debug statements in Tumblr. Should be enabled on each sharer.

a response to #346, touches #364
