### PR TITLE
Runtime linker error: dyld: Symbol not found: _NSURLIsExcludedFromBackupKey

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -812,7 +812,7 @@ NSString* SHKLocalizedString(NSString* key, ...)
         int result = setxattr(filePath, attrName, &attrValue, sizeof(attrValue), 0, 0);
         return result == 0;
     } else { // iOS >= 5.1
-        return [URL setResourceValue:[NSNumber numberWithBool:YES] forKey:@"NSURLIsExcludedFromBackupKey" error:nil];
+        return [URL setResourceValue:[NSNumber numberWithBool:YES] forKey:NSURLIsExcludedFromBackupKey error:nil];
     }
 }
 


### PR DESCRIPTION
Sharekit is resulting in the following runtime error on iPhone 5.0 simulator:
dyld: Symbol not found: _NSURLIsExcludedFromBackupKey
  Referenced from: /Users/dev/Library/Application Support/iPhone Simulator/5.0/Applications/AA733E5E-02C3-4021-AE61-2F49106113E9/myapp.app/myapp
  Expected in: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator5.0.sdk/System/Library/Frameworks/Foundation.framework/Foundation
 in /Users/dev/Library/Application Support/iPhone Simulator/5.0/Applications/AA733E5E-02C3-4021-AE61-2F49106113E9/myapp.app/myapp

My project is configured to build against the latest iOS sdk (i.e. 5.1) with a minimum deployment target of 5.0.

After investigating several solutions including macro bindings to iOS versions, this was the best solution I could find in the interim i.e. to remove the reference to the const string variable and insert the actual varialbe value directly.  See:
http://stackoverflow.com/questions/10635607/nsurlisexcludedfrombackupkey-crashes-before-ios-5-1
