### PR TITLE
Changed Foursquare cell identifier to fit with naming conventions. 

### DIFF
--- a/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2VenuesForm.m
+++ b/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2VenuesForm.m
@@ -181,7 +181,7 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    static NSString *CellIdentifier = @"SHKFoureSquareV2VenueCell";
+    static NSString *CellIdentifier = @"SHKFoursquareV2VenueCell";
     
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {


### PR DESCRIPTION
Changed from ...FoureSquare... to ...Foursquare...
