### PR TITLE
Backup Attribute Code Update

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -798,15 +798,26 @@ NSString* SHKLocalizedString(NSString* key, ...)
 
 - (BOOL)addSkipBackupAttributeToItemAtURL:(NSURL *)URL
 {
-    if (&NSURLIsExcludedFromBackupKey == nil) { // iOS <= 5.0.1
-        const char* filePath = [[URL path] fileSystemRepresentation];
-        
-        const char* attrName = "com.apple.MobileBackup";
+    const char* filePath = [[URL path] fileSystemRepresentation];
+    const char* attrName = "com.apple.MobileBackup";
+    if (&NSURLIsExcludedFromBackupKey == nil) {
+        // iOS 5.0.1 and lower
         u_int8_t attrValue = 1;
-        
         int result = setxattr(filePath, attrName, &attrValue, sizeof(attrValue), 0, 0);
         return result == 0;
-    } else { // iOS >= 5.1
+    }
+    else {
+        // First try and remove the extended attribute if it is present
+        int result = getxattr(filePath, attrName, NULL, sizeof(u_int8_t), 0, 0);
+        if (result != -1) {
+            // The attribute exists, we need to remove it
+            int removeResult = removexattr(filePath, attrName, 0);
+            if (removeResult == 0) {
+                NSLog(@"Removed extended attribute on file %@", URL);
+            }
+        }
+        
+        // Set the new key
         return [URL setResourceValue:[NSNumber numberWithBool:YES] forKey:NSURLIsExcludedFromBackupKey error:nil];
     }
 }


### PR DESCRIPTION
I just found some updated code for whether or not to add a backup attribute to the offlineQueue files. Anyway this was the issue: The code before won't work for files that were present when a user upgraded from 5.0.1 to 5.1. Then these would have the file attribute, but not the key. I checked for this case and migrate the files with this pull. This approach is to set both and use the actual NSString.
