### PR TITLE
SHKMail invalidates items when they have data that it can use

### DIFF
--- a/Classes/ShareKit/Sharers/Actions/Email/SHKMail.m
+++ b/Classes/ShareKit/Sharers/Actions/Email/SHKMail.m
@@ -98,6 +98,16 @@
 	return YES;
 }
 
+- (BOOL)validateItem
+{
+	BOOL isValid = [super validateItem];
+	
+	//we can send as long as there is something in one of these fields
+	if(isValid == NO && (item.URL || item.title || item.text || item.filename || item.image || item.mailBody))
+		isValid = YES;
+
+	return isValid;
+}
 
 
 #pragma mark -


### PR DESCRIPTION
This mainly happens when an item is created with init, when you want to set more than just the one field
