### PR TITLE
Small class type error corrected

### DIFF
--- a/Classes/ShareKit/Core/Categories/NSMutableDictionary+NSNullsToEmptyStrings.m
+++ b/Classes/ShareKit/Core/Categories/NSMutableDictionary+NSNullsToEmptyStrings.m
@@ -20,7 +20,7 @@
         if (object == [NSNull null]) {
             [self setObject:@"" forKey:key];
         }
-        else if ([object isKindOfClass:[NSDictionary class]]) {
+        else if ([object isKindOfClass:[NSMutableDictionary class]]) {
             [object convertNSNullsToEmptyStrings];
         }
     }


### PR DESCRIPTION
As this extension can be used in a different context than just
sharekit, this would cause a crash is it happens (NSDictionnary instead
of NSMutableDisctionnary)
