### PR TITLE
Fix double URI encode for extra OAuth parameters.

### DIFF
--- a/Classes/ShareKit/Core/Helpers/OAuth/OAMutableURLRequest.m
+++ b/Classes/ShareKit/Core/Helpers/OAuth/OAMutableURLRequest.m
@@ -224,7 +224,7 @@ signatureProvider:(id<OASignatureProviding, NSObject>)aProvider
     
 	
 	for(NSString *parameterName in [[extraOAuthParameters allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
-		[parameterPairs addObject:[[OARequestParameter requestParameterWithName:[parameterName URLEncodedString] value: [[extraOAuthParameters objectForKey:parameterName] URLEncodedString]] URLEncodedNameValuePair]];
+		[parameterPairs addObject:[[OARequestParameter requestParameterWithName:parameterName value:[extraOAuthParameters objectForKey:parameterName]] URLEncodedNameValuePair]];
 	}
 	
 	if (![[self valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"multipart/form-data"]) {


### PR DESCRIPTION
Fix double URI encode for extra OAuth parameters.
If set extra oauth parameters, for instance oath_calback, it makes signature invalid.Because of the each keys and values are encoded twice.
e.g. oauth_calback=http%253A%252F%252Fwww.example.com
fixed: oauth_calback=http%3A%2F%2Fwww.example.com
