### PR TITLE
Fix table background view color in iOS 6

### DIFF
--- a/Classes/ShareKit/UI/SHKFormController.m
+++ b/Classes/ShareKit/UI/SHKFormController.m
@@ -123,7 +123,10 @@
 	[super viewDidLoad];
 	
 	if (SHKCONFIG(formBackgroundColor) != nil)
-         self.tableView.backgroundColor = SHKCONFIG(formBackgroundColor);
+	{
+		self.tableView.backgroundView = nil;
+		self.tableView.backgroundColor = SHKCONFIG(formBackgroundColor);
+	}
 }
 
 

--- a/Classes/ShareKit/UI/SHKShareMenu.m
+++ b/Classes/ShareKit/UI/SHKShareMenu.m
@@ -76,7 +76,10 @@
     [super viewDidLoad];
     
     if (SHKCONFIG(formBackgroundColor) != nil)
+	{
+		self.tableView.backgroundView = nil;
         self.tableView.backgroundColor = SHKCONFIG(formBackgroundColor);
+	}
 }
 
 - (void)viewDidDisappear:(BOOL)animated


### PR DESCRIPTION
iOS 6 requires setting the table background view to nil for the custom background color to display properly.
