### PR TITLE
make SHKLocalizedStringFormat also search for main bundle path for localization resources.

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -778,14 +778,16 @@ void SHKSwizzle(Class c, SEL orig, SEL newClassName)
 
 NSString* SHKLocalizedStringFormat(NSString* key)
 {
-  static NSBundle* bundle = nil;
-  if (nil == bundle) {
-    NSString* path = [[SHK shareKitLibraryBundlePath] stringByAppendingPathComponent:@"ShareKit.bundle"];
-    bundle = [[NSBundle bundleWithPath:path] retain];
-    
-    NSCAssert(bundle != nil,@"ShareKit has been refactored to be used as Xcode subproject. Please follow the updated installation wiki and re-add it to the project. Please do not forget to clean project and clean build folder afterwards");
-  }
-  return [bundle localizedStringForKey:key value:key table:nil];
+    static NSBundle* bundle = nil;
+    if (nil == bundle) {
+        NSString* path = [[SHK shareKitLibraryBundlePath] stringByAppendingPathComponent:@"ShareKit.bundle"];
+        bundle = [[NSBundle bundleWithPath:path] retain];
+        if(nil == bundle) {
+            bundle = [[NSBundle bundleWithPath:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"ShareKit.bundle"]] retain];
+        }
+        NSCAssert(bundle != nil,@"ShareKit has been refactored to be used as Xcode subproject. Please follow the updated installation wiki and re-add it to the project. Please do not forget to clean project and clean build folder afterwards");
+    }
+    return [bundle localizedStringForKey:key value:key table:nil];
 }
 
 NSString* SHKLocalizedString(NSString* key, ...) 


### PR DESCRIPTION
SHKLocalizedStringFormat will also search for localisation resource in main bundle resource path (like the sharekit.plist) so that it work with cocoapods without pack the resource.
