### PR TITLE
BUGFIX: possibly problematic activity indicator frame

### DIFF
--- a/Classes/ShareKit/UI/SHKActivityIndicator.m
+++ b/Classes/ShareKit/UI/SHKActivityIndicator.m
@@ -43,6 +43,13 @@ static SHKActivityIndicator *_currentIndicator = nil;
 	if (_currentIndicator == nil)
 	{
 		UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];		
+		
+		if (keyWindow == nil) {
+			// this means the app is trying to do a ShareKit operation prior to having a UIWindow ready
+			// we don't want the singleton instance to have a messed up frame, so return a nil indicator for now...
+			return nil;
+		}
+		
 		CGFloat width = 160;
 		CGFloat height = 160;
 		CGRect centeredFrame = CGRectMake(round(keyWindow.bounds.size.width/2 - width/2),


### PR DESCRIPTION
Protected against instantiating SHKActivityIndicator's singleton instance too soon, and messing up its frame because of it.

(found when tried out the Facebook3.0 fork of troppoli)
