### PR TITLE
Should leave the SLCompose and TWCompose view controllers alone

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -160,11 +160,13 @@ BOOL SHKinit;
 
 /* method for sharers with custom UI, e.g. all social.framework sharers, print etc */
 - (void)showStandaloneViewController:(UIViewController *)vc {
-           
-    if ([vc respondsToSelector:@selector(modalPresentationStyle)])
+    
+    BOOL isSocialOrTwitterComposeVc = [vc respondsToSelector:@selector(setInitialText:)];
+
+    if ([vc respondsToSelector:@selector(modalPresentationStyle)] && !isSocialOrTwitterComposeVc)
         vc.modalPresentationStyle = [SHK modalPresentationStyleForController:vc];
     
-    if ([vc respondsToSelector:@selector(modalTransitionStyle)])
+    if ([vc respondsToSelector:@selector(modalTransitionStyle)] && !isSocialOrTwitterComposeVc)
         vc.modalTransitionStyle = [SHK modalTransitionStyle];
     
     // If a view is already being shown, hide it, and then try again


### PR DESCRIPTION
the modalPresentationStyle was distorting the background of the  SLComposeViewController and TWTweetComposeViewControllers. 

http://i.imgur.com/6QIPk.png

This problem was created in 9d985e3453a.

the transition style wasn't affecting it but i don't think it should be called on one of these specialised view controllers 
