### PR TITLE
Make Required FormDelegate methods Required

### DIFF
--- a/Classes/ShareKit/UI/SHKFormControllerLargeTextField.h
+++ b/Classes/ShareKit/UI/SHKFormControllerLargeTextField.h
@@ -25,7 +25,7 @@
 @end
 
 @protocol SHKFormControllerLargeTextFieldDelegate <NSObject> 
-
+@required
 - (void)sendForm:(SHKFormControllerLargeTextField *)form;
 + (NSString *)sharerTitle;
 - (void)sendDidCancel;


### PR DESCRIPTION
These are not tested with respondsToSelector so it's only logical to make them required.
