### PR TITLE
using correct header search path for Facebook target

### DIFF
--- a/ShareKit.xcodeproj/project.pbxproj
+++ b/ShareKit.xcodeproj/project.pbxproj
@@ -5008,7 +5008,7 @@
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				HEADER_SEARCH_PATHS = "\"$(BUILT_PRODUCTS_DIR)/facebook-ios-sdk/\"";
+				HEADER_SEARCH_PATHS = "$(SOURCE_ROOT)/Submodules/facebook-ios-sdk/**";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -5036,7 +5036,7 @@
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				HEADER_SEARCH_PATHS = "\"$(BUILT_PRODUCTS_DIR)/facebook-ios-sdk/\"";
+				HEADER_SEARCH_PATHS = "$(SOURCE_ROOT)/Submodules/facebook-ios-sdk/**";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				OTHER_LDFLAGS = (
 					"-ObjC",


### PR DESCRIPTION
This pull request addresses the 'FacebookSDK.h file not found' error when building using xcodebuild.

To verify, use command:
xcodebuild -sdk iphoneos -project Sharekit.xcodeproj -target Facebook -configuration Release
