### PR TITLE
bugfix crach when use + (id)shareURL

### DIFF
--- a/Classes/ShareKit/Core/Base Sharer Classes/SHKiOSSharer.m
+++ b/Classes/ShareKit/Core/Base Sharer Classes/SHKiOSSharer.m
@@ -27,7 +27,7 @@
     [sharerUIController addImage:self.item.image];
     [sharerUIController addURL:self.item.URL];
     
-    NSString *initialText = [NSString stringWithString:(self.item.shareType == SHKShareTypeText ? item.text : item.title)];
+    NSString *initialText = (self.item.shareType == SHKShareTypeText ? item.text : item.title)];
     
     NSString *tagString = [self joinedTags];
     if ([tagString length] > 0) initialText = [initialText stringByAppendingFormat:@" %@",tagString];


### PR DESCRIPTION
https://github.com/ShareKit/ShareKit/issues/612

**\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '**\* -[NSPlaceholderString initWithString:]: nil argument'

cause in SHKiOSSharer - (void)shareWithServiceType:(NSString *)serviceType

[NSString stringWithString:(self.item.shareType == SHKShareTypeText ? item.text : item.title)])

item.title is nil, then crash.
