### PR TITLE
[UI] Configure the compose controller subclass for any given sharer

### DIFF
--- a/Classes/ShareKit/Configuration/DefaultSHKConfigurator.h
+++ b/Classes/ShareKit/Configuration/DefaultSHKConfigurator.h
@@ -99,6 +99,7 @@
 - (Class)SHKShareMenuSubclass;
 - (Class)SHKShareMenuCellSubclass;
 - (Class)SHKFormControllerSubclass;
+- (Class)SHKComposeControllerForSharerClass:(Class)sharerClass;
 
 //SHKPrint
 - (NSNumber*)printOutputType;

--- a/Classes/ShareKit/Configuration/DefaultSHKConfigurator.m
+++ b/Classes/ShareKit/Configuration/DefaultSHKConfigurator.m
@@ -26,6 +26,7 @@
 //
 
 #import "DefaultSHKConfigurator.h"
+#import "SHKFoursquareV2.h"
 
 @implementation DefaultSHKConfigurator
 
@@ -337,6 +338,12 @@
     return NSClassFromString(@"SHKFormController");
 }
 
+- (Class)SHKComposeControllerForSharerClass:(Class)sharerClass {
+  if ([sharerClass isSubclassOfClass:[SHKFoursquareV2 class]])
+    return NSClassFromString(@"SHKFoursquareV2CheckInForm");
+  else
+    return NSClassFromString(@"SHKFormControllerLargeTextField");
+}
 /*
  Advanced Configuration
  ----------------------

--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.h
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.h
@@ -28,9 +28,9 @@
 
 #import <Foundation/Foundation.h>
 #import "SHKSharer.h"
-#import "SHKCustomFormControllerLargeTextField.h"
+#import "SHKFormControllerLargeTextField.h"
 
-@interface SHKFacebook : SHKSharer <SHKFormControllerLargeTextFieldDelegate>{
+@interface SHKFacebook : SHKSharer <SHKComposeViewControllerDelegate>{
 	NSMutableSet* pendingConnections;	// use a set so that connections can only be added once
 }
 @property (readonly,retain) NSMutableSet* pendingConnections; // sub classes can use the set

--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
@@ -681,8 +681,9 @@ static SHKFacebook *requestingPermisSHKFacebook=nil;
 
 - (void)showFacebookForm
 {
- 	SHKCustomFormControllerLargeTextField *rootView = [[SHKCustomFormControllerLargeTextField alloc] initWithNibName:nil bundle:nil delegate:self];  
- 	
+ 	SHKComposeAbstractViewController *rootView = [SHKComposeAbstractViewController controllerForSharerClass:[self class]];
+  rootView.delegate = self;
+  
     switch (self.item.shareType) {
         case SHKShareTypeText:
             rootView.text = item.text;
@@ -702,20 +703,19 @@ static SHKFacebook *requestingPermisSHKFacebook=nil;
     
     self.navigationBar.tintColor = SHKCONFIG_WITH_ARGUMENT(barTintForView:,self);
  	[self pushViewController:rootView animated:NO];
-    [rootView release];
     
     [[SHK currentHelper] showViewController:self];  
 }
 
-- (void)sendForm:(SHKCustomFormControllerLargeTextField *)form
+- (void)sendForm:(SHKFormControllerLargeTextField *)form
 {  
  	switch (self.item.shareType) {
         case SHKShareTypeText:
-            self.item.text = form.textView.text;
+            self.item.text = form.text;
             break;
         case SHKShareTypeImage:
         case SHKShareTypeURL:
-            self.item.text = form.textView.text;
+            self.item.text = form.text;
             break;
         default:
             break;

--- a/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2.h
+++ b/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2.h
@@ -38,9 +38,9 @@
 
 #import "SHKFoursquareV2Request.h"
 #import "SHKFoursquareV2Venue.h"
-#import "SHKCustomFormControllerLargeTextField.h"
+#import "SHKFormControllerLargeTextField.h"
 
-@interface SHKFoursquareV2 : SHKSharer <SHKFormControllerLargeTextFieldDelegate> {
+@interface SHKFoursquareV2 : SHKSharer <SHKComposeViewControllerDelegate> {
     NSString *_clientId;
     NSURL *_authorizeCallbackURL;
     

--- a/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2.m
+++ b/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2.m
@@ -219,18 +219,18 @@ static NSString *accessTokenKey = @"accessToken";
 
 - (void)showFoursquareV2CheckInForm;
 {
-    SHKFoursquareV2CheckInForm *checkInForm = [[SHKFoursquareV2CheckInForm alloc] initWithNibName:nil bundle:nil delegate:self];	
-    checkInForm.text = item.text;       
+    SHKComposeAbstractViewController *checkInForm = [SHKComposeAbstractViewController controllerForSharerClass:[self class]];
+    checkInForm.delegate = self;
+    checkInForm.text = item.text;
     checkInForm.maxTextLength = 140;  
     self.navigationBar.tintColor = SHKCONFIG_WITH_ARGUMENT(barTintForView:,self);
 	
 	[self pushViewController:checkInForm animated:YES];	
-    [checkInForm release];
 }
 
-- (void)sendForm:(SHKCustomFormControllerLargeTextField *)form
+- (void)sendForm:(SHKFormControllerLargeTextField *)form
 {  
- 	self.item.text = form.textView.text;
+ 	self.item.text = form.text;
  	[self startCheckInRequest];
 }
 

--- a/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2CheckInForm.h
+++ b/Classes/ShareKit/Sharers/Services/FoursquareV2/SHKFoursquareV2CheckInForm.h
@@ -25,9 +25,9 @@
 //
 //
 
-#import "SHKCustomFormControllerLargeTextField.h"
+#import "SHKFormControllerLargeTextField.h"
 
-@interface SHKFoursquareV2CheckInForm : SHKCustomFormControllerLargeTextField {
+@interface SHKFoursquareV2CheckInForm : SHKFormControllerLargeTextField {
 
 }
 

--- a/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedIn.h
+++ b/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedIn.h
@@ -25,10 +25,10 @@
 //
 
 #import "SHKOAuthSharer.h"
-#import "SHKCustomFormControllerLargeTextField.h"
+#import "SHKFormControllerLargeTextField.h"
 
 extern NSString *SHKLinkedInVisibilityCodeKey;
 
-@interface SHKLinkedIn : SHKOAuthSharer <SHKFormControllerLargeTextFieldDelegate>
+@interface SHKLinkedIn : SHKOAuthSharer <SHKComposeViewControllerDelegate>
 
 @end

--- a/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedIn.m
+++ b/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedIn.m
@@ -138,7 +138,8 @@ NSString *SHKLinkedInVisibilityCodeKey = @"visibility.code";
 
 - (void)showSHKTextForm
 {
-	SHKCustomFormControllerLargeTextField *rootView = [[SHKCustomFormControllerLargeTextField alloc] initWithNibName:nil bundle:nil delegate:self];	
+    SHKComposeAbstractViewController *rootView = [SHKComposeAbstractViewController controllerForSharerClass:[self class]];
+    rootView.delegate = self;
 	
     if (item.shareType == SHKShareTypeURL) {
         rootView.text = item.title;
@@ -152,7 +153,6 @@ NSString *SHKLinkedInVisibilityCodeKey = @"visibility.code";
     self.navigationBar.tintColor = SHKCONFIG_WITH_ARGUMENT(barTintForView:,self);
 	
 	[self pushViewController:rootView animated:NO];
-    [rootView release];
 	
 	[[SHK currentHelper] showViewController:self];	
 }
@@ -175,12 +175,12 @@ NSString *SHKLinkedInVisibilityCodeKey = @"visibility.code";
 #pragma mark -
 #pragma mark SHKCustomFormControllerLargeTextField delegate
 
-- (void)sendForm:(SHKCustomFormControllerLargeTextField *)form
+- (void)sendForm:(SHKFormControllerLargeTextField *)form
 {	
     if (item.shareType == SHKShareTypeURL) {
-        item.title = form.textView.text;
+        item.title = form.text;
     } else {
-        item.text = form.textView.text;
+        item.text = form.text;
     }
 	[self tryToSend];
 }

--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.h
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.h
@@ -27,9 +27,9 @@
 
 #import <Foundation/Foundation.h>
 #import "SHKOAuthSharer.h"
-#import "SHKCustomFormControllerLargeTextField.h"
+#import "SHKFormControllerLargeTextField.h"
 
-@interface SHKTwitter : SHKOAuthSharer <SHKFormControllerLargeTextFieldDelegate>
+@interface SHKTwitter : SHKOAuthSharer <SHKComposeViewControllerDelegate>
 {	
 	BOOL xAuth;		
 }

--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -330,7 +330,8 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
 
 - (void)showTwitterForm
 {
-	SHKCustomFormControllerLargeTextField *rootView = [[SHKCustomFormControllerLargeTextField alloc] initWithNibName:nil bundle:nil delegate:self];	
+ 	SHKComposeAbstractViewController *rootView = [SHKComposeAbstractViewController controllerForSharerClass:[self class]];
+  rootView.delegate = self;
 	
 	rootView.text = [item customValueForKey:@"status"];
 	rootView.maxTextLength = 140;
@@ -340,14 +341,13 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
 	self.navigationBar.tintColor = SHKCONFIG_WITH_ARGUMENT(barTintForView:,self);
 	
 	[self pushViewController:rootView animated:NO];
-	[rootView release];
 	
 	[[SHK currentHelper] showViewController:self];	
 }
 
-- (void)sendForm:(SHKCustomFormControllerLargeTextField *)form
+- (void)sendForm:(SHKFormControllerLargeTextField *)form
 {	
-	[item setCustomValue:form.textView.text forKey:@"status"];
+	[item setCustomValue:form.text forKey:@"status"];
 	[self tryToSend];
 }
 

--- a/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakte.h
+++ b/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakte.h
@@ -27,7 +27,7 @@
 
 #import <Foundation/Foundation.h>
 #import "SHKSharer.h"
-#import "SHKCustomFormControllerLargeTextField.h"
+#import "SHKFormControllerLargeTextField.h"
 
 static NSString *const kSHKVkonakteUserId=@"kSHKVkontakteUserId";
 static NSString *const kSHKVkontakteAccessTokenKey=@"kSHKVkontakteAccessToken";
@@ -35,7 +35,7 @@ static NSString *const kSHKVkontakteExpiryDateKey=@"kSHKVkontakteExpiryDate";
 static NSString *const kSHKVkontakteAccessCodeKey=@"kSHKVkontakteAccessCode";
 static NSString *const kSHKVkonakteUserInfo=@"kSHKVkontakteUserInfo";
 
-@interface SHKVkontakte : SHKSharer <SHKFormControllerLargeTextFieldDelegate>
+@interface SHKVkontakte : SHKSharer <SHKComposeViewControllerDelegate>
 {
 	BOOL isCaptcha;
 }

--- a/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakte.m
+++ b/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakte.m
@@ -337,18 +337,19 @@
 
 - (void)showVkontakteForm
 {
- 	SHKCustomFormControllerLargeTextField *rootView = [[SHKCustomFormControllerLargeTextField alloc] initWithNibName:nil bundle:nil delegate:self];  
+ 	SHKComposeAbstractViewController *rootView = [SHKComposeAbstractViewController controllerForSharerClass:[self class]];
+
+  rootView.delegate = self;
     
  	rootView.text = item.text;
 	self.navigationBar.tintColor = SHKCONFIG_WITH_ARGUMENT(barTintForView:,self);
  	[self pushViewController:rootView animated:NO];
-	[rootView release];
 	[[SHK currentHelper] showViewController:self];  
 }
 
-- (void)sendForm:(SHKCustomFormControllerLargeTextField *)form
+- (void)sendForm:(SHKFormControllerLargeTextField *)form
 {  
- 	self.item.text = form.textView.text;
+ 	self.item.text = form.text;
  	[self tryToSend];
 }
 

--- a/Classes/ShareKit/UI/SHKComposeAbstractViewController.h
+++ b/Classes/ShareKit/UI/SHKComposeAbstractViewController.h
@@ -1,9 +1,9 @@
 //
-//  SHKCustomFormControllerLargeTextField.m
+//  SHKComposeAbstractViewController.h
 //  ShareKit
 //
-//  Created by Nathan Weiner on 6/28/10.
-
+//  Created by Euan Lau on 12/11/12.
+//
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -25,11 +25,23 @@
 //
 //
 
-#import "SHKCustomFormControllerLargeTextField.h"
+#import <UIKit/UIKit.h>
 
+@protocol SHKComposeViewControllerDelegate;
 
-@implementation SHKCustomFormControllerLargeTextField
+@interface SHKComposeAbstractViewController : UIViewController <UITextViewDelegate>
 
-// See http://getsharekit.com/customize/ for additional information on customizing
+@property (nonatomic, assign) id <SHKComposeViewControllerDelegate> delegate;
+
+// these properties are used for counter text display only.
+// Counter shows, only if they are set by your sharer.
+@property NSUInteger maxTextLength;
+@property (nonatomic, retain) UIImage *image;//ready for showing up image, like ios5 twitter
+@property NSUInteger imageTextLength; //set only if image subtracts from text length (e.g. Twitter)
+@property BOOL hasLink; //only if the link is not part of the text in a text view
+@property BOOL allowSendingEmptyMessage;
+@property (nonatomic, retain) NSString *text;
+
++ (SHKComposeAbstractViewController *)controllerForSharerClass:(Class)sharerClass;
 
 @end

--- a/Classes/ShareKit/UI/SHKComposeAbstractViewController.m
+++ b/Classes/ShareKit/UI/SHKComposeAbstractViewController.m
@@ -1,0 +1,73 @@
+//
+//  SHKComposeAbstractViewController.m
+//  ShareKit
+//
+//  Created by Euan Lau on 12/11/12.
+//
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+//
+
+#import "SHKComposeAbstractViewController.h"
+#import "SHK.h"
+#import "SHKConfiguration.h"
+
+@interface SHKComposeAbstractViewController ()
+
+@end
+
+@implementation SHKComposeAbstractViewController
+
+@synthesize delegate = _delegate;
+@synthesize maxTextLength = _maxTextLength;
+@synthesize imageTextLength = _imageTextLength;
+@synthesize allowSendingEmptyMessage = _allowSendingEmptyMessage;
+@synthesize hasLink = _hasLink;
+@synthesize text = _text;
+@synthesize image = _image;
+
++ (SHKComposeAbstractViewController *)controllerForSharerClass:(Class)sharerClass
+{
+  return [[[SHKCONFIG_WITH_ARGUMENT(SHKComposeControllerForSharerClass:,sharerClass) alloc]
+           initWithNibName:nil bundle:nil] autorelease];
+}
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+	if ((self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]))
+	{
+    _maxTextLength = 0;
+    _imageTextLength = 0;
+    _allowSendingEmptyMessage = NO;
+    _hasLink = NO;
+	}
+	return self;
+}
+
+- (void)dealloc
+{
+  _delegate = nil;
+  [_text release];
+  [_image release];
+  [super dealloc];
+}
+
+
+@end

--- a/Classes/ShareKit/UI/SHKComposeViewControllerDelegate.h
+++ b/Classes/ShareKit/UI/SHKComposeViewControllerDelegate.h
@@ -1,9 +1,9 @@
 //
-//  SHKCustomFormControllerLargeTextField.h
+//  SHKComposeViewControllerDelegate.h
 //  ShareKit
 //
-//  Created by Nathan Weiner on 6/28/10.
-
+//  Created by Euan Lau on 12/11/12.
+//
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -26,10 +26,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SHKFormControllerLargeTextField.h"
+@class SHKComposeAbstractViewController;
 
-@interface SHKCustomFormControllerLargeTextField : SHKFormControllerLargeTextField {
-
-}
+@protocol SHKComposeViewControllerDelegate <NSObject>
+@required
+- (void)sendForm:(SHKComposeAbstractViewController *)form;
++ (NSString *)sharerTitle;
+- (void)sendDidCancel;
 
 @end

--- a/Classes/ShareKit/UI/SHKFormControllerLargeTextField.h
+++ b/Classes/ShareKit/UI/SHKFormControllerLargeTextField.h
@@ -4,31 +4,9 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "SHKComposeAbstractViewController.h"
+#import "SHKComposeViewControllerDelegate.h"
 
-@protocol SHKFormControllerLargeTextFieldDelegate;
-
-@interface SHKFormControllerLargeTextField : UIViewController <UITextViewDelegate>
-
-@property (nonatomic, readonly, assign) id <SHKFormControllerLargeTextFieldDelegate> delegate;
-@property (nonatomic, retain) UITextView *textView;
-
-// these properties are used for counter text display only. 
-// Counter shows, only if they are set by your sharer.
-@property NSUInteger maxTextLength;
-@property (nonatomic, retain) UIImage *image;//ready for showing up image, like ios5 twitter
-@property NSUInteger imageTextLength; //set only if image subtracts from text length (e.g. Twitter)
-@property BOOL hasLink; //only if the link is not part of the text in a text view
-@property BOOL allowSendingEmptyMessage;
-@property (nonatomic, retain) NSString *text;
-
-- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil delegate:(id <SHKFormControllerLargeTextFieldDelegate>)aDelegate;
-
-@end
-
-@protocol SHKFormControllerLargeTextFieldDelegate <NSObject> 
-@required
-- (void)sendForm:(SHKFormControllerLargeTextField *)form;
-+ (NSString *)sharerTitle;
-- (void)sendDidCancel;
+@interface SHKFormControllerLargeTextField : SHKComposeAbstractViewController <UITextViewDelegate>
 
 @end

--- a/Classes/ShareKit/UI/SHKFormControllerLargeTextField.m
+++ b/Classes/ShareKit/UI/SHKFormControllerLargeTextField.m
@@ -9,6 +9,8 @@
 @interface SHKFormControllerLargeTextField ()
 
 @property (nonatomic, retain) UILabel *counter;
+@property (nonatomic, retain) UITextView *textView;
+
 @property BOOL shareIsCancelled;
 
 - (void)layoutCounter;
@@ -23,33 +25,16 @@
 
 @implementation SHKFormControllerLargeTextField
 
-@synthesize delegate, textView, maxTextLength;
-@synthesize counter, hasLink, image, imageTextLength;
-@synthesize text;
+@synthesize textView;
+@synthesize counter;
 @synthesize shareIsCancelled;
-@synthesize allowSendingEmptyMessage;
 
 - (void)dealloc 
 {
 	[textView release];
 	[counter release];
-	[text release];
-	[image release];
 	
 	[super dealloc];
-}
-
-- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil delegate:(id <SHKFormControllerLargeTextFieldDelegate>)aDelegate
-{
-	if ((self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil])) 
-	{		
-		delegate = aDelegate;
-		imageTextLength = 0;
-		hasLink = NO;
-		maxTextLength = 0;
-        allowSendingEmptyMessage = NO;
-	}
-	return self;
 }
 
 - (void)loadView 
@@ -74,7 +59,7 @@
 	[super viewWillAppear:animated];
 	
 	// save to set the text now
-	textView.text = text;
+	textView.text = self.text;
 	
 	[self setupBarButtonItems];
 }
@@ -247,6 +232,10 @@
 	if (self.maxTextLength || self.image || self.hasLink) return YES;
 	
 	return NO;
+}
+
+- (NSString *)text {
+  return self.textView.text;
 }
 
 #pragma mark UITextView delegate

--- a/ShareKit.xcodeproj/project.pbxproj
+++ b/ShareKit.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		2892E4100DC94CBA00A64D0F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2892E40F0DC94CBA00A64D0F /* CoreGraphics.framework */; };
 		28AD73600D9D9599002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD735F0D9D9599002E5188 /* MainWindow.xib */; };
 		28F335F11007B36200424DE2 /* RootViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28F335F01007B36200424DE2 /* RootViewController.xib */; };
+		2BB0D4241677B6FC00023546 /* SHKComposeAbstractViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BB0D4221677B6FB00023546 /* SHKComposeAbstractViewController.h */; };
+		2BB0D4261677B6FC00023546 /* SHKComposeAbstractViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BB0D4231677B6FB00023546 /* SHKComposeAbstractViewController.m */; };
 		4312CF7C11CB33E200E61D7A /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4312CF7B11CB33E200E61D7A /* MessageUI.framework */; };
 		43A5382811DBE480004A1712 /* example.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 43A5382611DBE480004A1712 /* example.pdf */; };
 		43A5382911DBE480004A1712 /* sanFran.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 43A5382711DBE480004A1712 /* sanFran.jpg */; };
@@ -26,7 +28,6 @@
 		43D1DEF011D5CDD200550D75 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43D1DEEF11D5CDD200550D75 /* SystemConfiguration.framework */; };
 		43EF406E11D3FFF800B1F700 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43EF406D11D3FFF800B1F700 /* Security.framework */; };
 		7A0F91D5156BA2A0009CB40A /* SHKCustomFormFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A536B111DBE3B9004A1712 /* SHKCustomFormFieldCell.m */; };
-		7A0F91D6156BA2A0009CB40A /* SHKCustomFormControllerLargeTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BD2BD53153431390042EB86 /* SHKCustomFormControllerLargeTextField.m */; };
 		7A0F91D9156BA2A0009CB40A /* SHK.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A536A711DBE3B9004A1712 /* SHK.m */; };
 		7A0F91DA156BA2A0009CB40A /* SHKItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A536A911DBE3B9004A1712 /* SHKItem.m */; };
 		7A0F91DB156BA2A0009CB40A /* SHKOfflineSharer.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A536AB11DBE3B9004A1712 /* SHKOfflineSharer.m */; };
@@ -459,8 +460,9 @@
 		28AD735F0D9D9599002E5188 /* MainWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindow.xib; sourceTree = "<group>"; };
 		28F335F01007B36200424DE2 /* RootViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RootViewController.xib; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		3BD2BD52153431390042EB86 /* SHKCustomFormControllerLargeTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SHKCustomFormControllerLargeTextField.h; sourceTree = "<group>"; };
-		3BD2BD53153431390042EB86 /* SHKCustomFormControllerLargeTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SHKCustomFormControllerLargeTextField.m; sourceTree = "<group>"; };
+		2BB0D4221677B6FB00023546 /* SHKComposeAbstractViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SHKComposeAbstractViewController.h; sourceTree = "<group>"; };
+		2BB0D4231677B6FB00023546 /* SHKComposeAbstractViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SHKComposeAbstractViewController.m; sourceTree = "<group>"; };
+		2BB0D4291677B7FE00023546 /* SHKComposeViewControllerDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SHKComposeViewControllerDelegate.h; sourceTree = "<group>"; };
 		427FBAB11592F7C90024F825 /* ENOAuthViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ENOAuthViewController.h; sourceTree = "<group>"; };
 		427FBAB21592F7C90024F825 /* ENOAuthViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ENOAuthViewController.m; sourceTree = "<group>"; };
 		427FBAED15934A0D0024F825 /* GTMNSString+HTML.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GTMNSString+HTML.h"; sourceTree = "<group>"; };
@@ -1656,6 +1658,9 @@
 				43A536FB11DBE3B9004A1712 /* SHKOAuthView.m */,
 				43A536FC11DBE3B9004A1712 /* SHKShareMenu.h */,
 				43A536FD11DBE3B9004A1712 /* SHKShareMenu.m */,
+				2BB0D4221677B6FB00023546 /* SHKComposeAbstractViewController.h */,
+				2BB0D4231677B6FB00023546 /* SHKComposeAbstractViewController.m */,
+				2BB0D4291677B7FE00023546 /* SHKComposeViewControllerDelegate.h */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -1665,8 +1670,6 @@
 			children = (
 				43A536B011DBE3B9004A1712 /* SHKCustomFormFieldCell.h */,
 				43A536B111DBE3B9004A1712 /* SHKCustomFormFieldCell.m */,
-				3BD2BD52153431390042EB86 /* SHKCustomFormControllerLargeTextField.h */,
-				3BD2BD53153431390042EB86 /* SHKCustomFormControllerLargeTextField.m */,
 			);
 			name = Form;
 			sourceTree = "<group>";
@@ -1902,6 +1905,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2BB0D4241677B6FC00023546 /* SHKComposeAbstractViewController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2902,7 +2906,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7A0F91D5156BA2A0009CB40A /* SHKCustomFormFieldCell.m in Sources */,
-				7A0F91D6156BA2A0009CB40A /* SHKCustomFormControllerLargeTextField.m in Sources */,
 				7A0F91D9156BA2A0009CB40A /* SHK.m in Sources */,
 				7A0F91DA156BA2A0009CB40A /* SHKItem.m in Sources */,
 				7A0F91DB156BA2A0009CB40A /* SHKOfflineSharer.m in Sources */,
@@ -2931,6 +2934,7 @@
 				7ABCDBB3157757D1003BBFFD /* SHKFormFieldCellOptionPicker.m in Sources */,
 				7AB8051115AC7BCC004FB430 /* GTMNSString+HTML.m in Sources */,
 				7A56BFC41659173D00134F04 /* SHKiOSSharer.m in Sources */,
+				2BB0D4261677B6FC00023546 /* SHKComposeAbstractViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Currently, there is no way to change the compose view without changing the sharer class directly. 
This change will allow people to configure the compose controller subclass to be used for different type of sharer by overriding [DefaultSHKConfigurator  SHKComposeControllerForSharerClass:] in their own configuration subclass. 

Example:

``` objective-c
- (Class)SHKComposeControllerForSharerClass:(Class)sharerClass {
  if ([sharerClass isSubclassOfClass:[SHKFoursquareV2 class]])
    return NSClassFromString(@"SHKFoursquareV2CheckInForm");
  else
    return NSClassFromString(@"SHKFormControllerLargeTextField");
}
```
