### PR TITLE
Instagram fixes

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Instagram/SHKInstagram.m
+++ b/Classes/ShareKit/Sharers/Services/Instagram/SHKInstagram.m
@@ -57,8 +57,7 @@
 
 + (BOOL)canShareImage
 {
-    NSURL *instagramURL = [NSURL URLWithString:@"instagram://app"];
-	return 	[[UIApplication sharedApplication] canOpenURL:instagramURL];
+    return YES;
 }
 
 + (BOOL)shareRequiresInternetConnection
@@ -79,6 +78,12 @@
 
 #pragma mark -
 #pragma mark Configuration : Dynamic Enable
+
++ (BOOL)canShare
+{
+	NSURL *instagramURL = [NSURL URLWithString:@"instagram://app"];
+	return [[UIApplication sharedApplication] canOpenURL:instagramURL];
+}
 
 + (BOOL)canAutoShare
 {


### PR DESCRIPTION
Reposting #632.
- Check for share type when choosing favorite items (prevents instagram from showing in the favorites list if the app is not installed, and should also improve the UX for other share types).
- Use the com.instagram.exclusivegram UTI for Instagram, so only Instagram is on the open with list. 
