### PR TITLE
Add customisable modalTransitionStyle

### DIFF
--- a/Classes/ShareKit/Configuration/DefaultSHKConfigurator.h
+++ b/Classes/ShareKit/Configuration/DefaultSHKConfigurator.h
@@ -86,7 +86,7 @@
 - (UIColor*)formFontColor;
 - (UIColor*)formBackgroundColor;
 - (NSString*)modalPresentationStyleForController:(UIViewController *)controller;
-- (NSString*)modalTransitionStyle;
+- (NSString*)modalTransitionStyleForController:(UIViewController *)controller;
 - (NSNumber*)maxFavCount;
 - (NSNumber*)autoOrderFavoriteSharers;
 - (NSString*)favsPrefixKey;

--- a/Classes/ShareKit/Configuration/DefaultSHKConfigurator.m
+++ b/Classes/ShareKit/Configuration/DefaultSHKConfigurator.m
@@ -269,7 +269,7 @@
 	return @"UIModalPresentationFormSheet";// See: http://developer.apple.com/iphone/library/documentation/UIKit/Reference/UIViewController_Class/Reference/Reference.html#//apple_ref/occ/instp/UIViewController/modalPresentationStyle
 }
 
-- (NSString*)modalTransitionStyle {
+- (NSString*)modalTransitionStyleForController:(UIViewController *)controller {
 	return @"UIModalTransitionStyleCoverVertical";// See: http://developer.apple.com/iphone/library/documentation/UIKit/Reference/UIViewController_Class/Reference/Reference.html#//apple_ref/occ/instp/UIViewController/modalTransitionStyle
 }
 // ShareMenu Ordering

--- a/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
+++ b/Classes/ShareKit/Core/Base Sharer Classes/SHKSharer.m
@@ -183,7 +183,7 @@
 			self.modalPresentationStyle = [SHK modalPresentationStyleForController:self];
 		
 		if ([self respondsToSelector:@selector(modalTransitionStyle)])
-			self.modalTransitionStyle = [SHK modalTransitionStyle];
+			self.modalTransitionStyle = [SHK modalTransitionStyleForController:self];
 	}
 	return self;
 }

--- a/Classes/ShareKit/Core/SHK.h
+++ b/Classes/ShareKit/Core/SHK.h
@@ -71,7 +71,7 @@ extern NSString * const SHKHideCurrentViewFinishedNotification;
 
 + (UIBarStyle)barStyle;
 + (UIModalPresentationStyle)modalPresentationStyleForController:(UIViewController *)controller;
-+ (UIModalTransitionStyle)modalTransitionStyle;
++ (UIModalTransitionStyle)modalTransitionStyleForController:(UIViewController *)controller;
 
 #pragma mark -
 #pragma mark Favorites

--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -190,7 +190,7 @@ BOOL SHKinit;
         vc.modalPresentationStyle = [SHK modalPresentationStyleForController:vc];
     
     if ([vc respondsToSelector:@selector(modalTransitionStyle)] && !isSocialOrTwitterComposeVc)
-        vc.modalTransitionStyle = [SHK modalTransitionStyle];
+        vc.modalTransitionStyle = [SHK modalTransitionStyleForController:vc];
     
     UIViewController *topViewController = [self rootViewForUIDisplay];
     
@@ -306,15 +306,17 @@ BOOL SHKinit;
 	return UIModalPresentationCurrentContext;
 }
 
-+ (UIModalTransitionStyle)modalTransitionStyle
++ (UIModalTransitionStyle)modalTransitionStyleForController:(UIViewController *)controller
 {
-	if ([SHKCONFIG(modalTransitionStyle) isEqualToString:@"UIModalTransitionStyleFlipHorizontal"])
+    NSString *transitionString = SHKCONFIG_WITH_ARGUMENT(modalTransitionStyleForController:, controller);
+    
+	if ([transitionString isEqualToString:@"UIModalTransitionStyleFlipHorizontal"])
 		return UIModalTransitionStyleFlipHorizontal;
 	
-	else if ([SHKCONFIG(modalTransitionStyle) isEqualToString:@"UIModalTransitionStyleCrossDissolve"])
+	else if ([transitionString isEqualToString:@"UIModalTransitionStyleCrossDissolve"])
 		return UIModalTransitionStyleCrossDissolve;
 	
-	else if ([SHKCONFIG(modalTransitionStyle) isEqualToString:@"UIModalTransitionStylePartialCurl"])
+	else if ([transitionString isEqualToString:@"UIModalTransitionStylePartialCurl"])
 		return UIModalTransitionStylePartialCurl;
 	
 	return UIModalTransitionStyleCoverVertical;


### PR DESCRIPTION
Adds the ability to easily customise the modalTransitionStyle exactly like the current modalPresentationStyle tweaks made 6 months ago... https://github.com/ShareKit/ShareKit/pull/482

Working on a ShareKit integration for Buffer that uses a different transition style and wasn't able to find anyway of doing it easily like the below code in my configurator.

```
- (NSString *)modalTransitionStyleForController:(id)controller
{
    if ([controller isKindOfClass:NSClassFromString(@"SHKBuffer")]) {
        return @"UIModalTransitionStyleCrossDissolve";
    }
    return [self modalPresentationStyle];
}

- (NSString *)modalTransitionStyle
{
    return @"UIModalTransitionStyleCoverVertical";
}
```
