### PR TITLE
Protect against nil being passed to [SHK error:]

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -655,12 +655,18 @@ static NSDictionary *sharersDictionary = nil;
 
 + (NSError *)error:(NSString *)description, ...
 {
-	va_list args;
-    va_start(args, description);
-    NSString *string = [[[NSString alloc] initWithFormat:description arguments:args] autorelease];
-    va_end(args);
-	
-	return [NSError errorWithDomain:@"sharekit" code:1 userInfo:[NSDictionary dictionaryWithObject:string forKey:NSLocalizedDescriptionKey]];
+	NSDictionary *userInfo = nil;
+
+	if (description) {
+		va_list args;
+		va_start(args, description);
+		NSString *string = [[[NSString alloc] initWithFormat:description arguments:args] autorelease];
+		va_end(args);
+
+		userInfo = [NSDictionary dictionaryWithObject:string forKey:NSLocalizedDescriptionKey];
+	}
+
+	return [NSError errorWithDomain:@"sharekit" code:1 userInfo:userInfo];
 }
 
 #pragma mark -


### PR DESCRIPTION
It appears that the read it later sharer returns an error code sometimes, but doesn't set the `X-Error` header leading to nil being passed to `[SHK error:]`. This causes the crash shown in the image below.

![crash log](http://f.cl.ly/items/1v1t0T2x2h2W0i0I0A00/Screen_Shot_2013-02-22_at_10.07.09_PM.png)
