### PR TITLE
Added a Podspec 

### DIFF
--- a/ShareKit.podspec
+++ b/ShareKit.podspec
@@ -1,0 +1,77 @@
+Pod::Spec.new do |s|
+  s.name          = 'ShareKit'
+  s.version       = '2.0'
+  s.platform      = :ios, '5.0'
+  s.summary       = 'Drop in sharing features for all iPhone and iPad apps.'
+  s.homepage      = 'http://getsharekit.com/'
+  s.author        = 'ShareKit Community'
+  s.source        = { :git  => 'git://github.com/ShareKit/ShareKit.git' }
+  s.license       = { :type => 'MIT',
+                      :text => %Q|Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n| +
+                               %Q|The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n| +
+                               %Q|THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE| }
+  s.resource      = 'Classes/ShareKit/ShareKit.bundle', 'Classes/ShareKit/Core/SHKSharers.plist'
+  s.source_files  = 'Classes/ShareKit/{Configuration,Core,Customize UI,UI,Reachability}/**/*.{h,m,c}', 'Classes/ShareKit/Sharers/Actions/**/*.{h,m,c}'
+  s.exclude_files = 'Classes/ShareKit/LegacySHKConfigurator.*'
+  s.frameworks    = 'SystemConfiguration', 'Security', 'MessageUI'
+
+  s.dependency 'SSKeychain', '0.2.1'
+  s.dependency 'Reachability'
+
+  s.subspec 'Evernote' do |evernote|
+    evernote.source_files = 'Classes/ShareKit/Sharers/Services/Evernote/**/*.{h,m}'
+    evernote.dependency 'Evernote-SDK-iOS', "1.0.1"
+  end
+
+  s.subspec 'Facebook' do |facebook|
+    facebook.source_files   = 'Classes/ShareKit/Sharers/Services/Facebook/**/*.{h,m}'
+    facebook.dependency 'Facebook-iOS-SDK',"~> 3.2.1"
+  end
+
+  s.subspec 'Flickr' do |flickr|
+    flickr.source_files = 'Classes/ShareKit/Sharers/Services/Flickr/SHK*.{h,m}'
+    flickr.framework = 'SystemConfiguration', 'CFNetwork'
+    flickr.dependency 'objectiveflickr', "2.0.2"
+  end
+
+  s.subspec 'Foursquare' do |foursquare|
+    foursquare.source_files = 'Classes/ShareKit/Sharers/Services/FoursquareV2/**/*.{h,m}'
+    foursquare.framework = 'CoreLocation'
+    foursquare.dependency 'SBJson'
+  end
+
+  s.subspec 'GoogleReader' do |googlereader|
+    googlereader.source_files = 'Classes/ShareKit/Sharers/Services/Google Reader/**/*.{h,m}'
+  end
+
+  s.subspec 'Instapaper' do |instapaper|
+    instapaper.source_files = 'Classes/ShareKit/Sharers/Services/Instapaper/**/*.{h,m}'
+  end
+
+  s.subspec 'LinkedIn' do |linkedin|
+    linkedin.source_files = 'Classes/ShareKit/Sharers/Services/LinkedIn/**/*.{h,m}'
+  end
+
+  s.subspec 'Pinboard' do |pinboard|
+    pinboard.source_files = 'Classes/ShareKit/Sharers/Services/Pinboard/**/*.{h,m}'
+  end
+
+  s.subspec 'ReadItLater' do |readitlater|
+    readitlater.source_files = 'Classes/ShareKit/Sharers/Services/Read It Later/**/*.{h,m}'
+  end
+
+  s.subspec 'Tumblr' do |tumblr|
+    tumblr.source_files = 'Classes/ShareKit/Sharers/Services/Tumblr/**/*.{h,m}'
+  end
+
+  s.subspec 'Twitter' do |twitter|
+    twitter.source_files = 'Classes/ShareKit/Sharers/Services/Twitter/**/*.{h,m}'
+    twitter.framework = 'Twitter'
+    twitter.dependency 'JSONKit'
+  end
+
+  s.subspec 'Vkontakte' do |vkontakte|
+    vkontakte.source_files = 'Classes/ShareKit/Sharers/Services/Vkontakte/**/*.{h,m}'
+    vkontakte.dependency 'JSONKit'
+  end
+end


### PR DESCRIPTION
I added a Podspec that points to the master branch of ShareKit/ShareKit.   It works.  I have a test project that you can use to verify.

---

Note: I tried pointing it at v2.0, but was running into an issue with **LegacySHKConfiguration.m**.  This file does not build because it depends on SHKConfig.h which is no longer present.  I exclude it in the current Podspec (using 'exclude_files'), and the pod installs.  However, if I include the tag v2.0 in the podspec, Cocoapods seems to ignore the exclude_files directive, and tries to compile it.  

One solution to this is to exclude the file; Is that feasible?  I think we will then be able to point at a tag in the podspec.  
