### PR TITLE
Remove unneeded imports

### DIFF
--- a/Classes/ShareKit/Core/SHK.h
+++ b/Classes/ShareKit/Core/SHK.h
@@ -30,11 +30,6 @@
 #import <Foundation/Foundation.h>
 #import "DefaultSHKConfigurator.h"
 #import "SHKItem.h"
-#import "SHKActionSheet.h"
-#import "SHKRequest.h"
-#import "SHKActivityIndicator.h"
-#import "SHKFormFieldSettings.h"
-#import "UIWebView+SHK.h"
 
 extern NSString * const SHKSendDidStartNotification;
 extern NSString * const SHKSendDidFinishNotification;


### PR DESCRIPTION
The imports add a lot of header dependencies and if create framework using ShareKit source one should include almost all headers in the Public headers section - otherwise it will not compile.
