### PR TITLE
BUG FIX: Issue #710 Public share on YouTube sharer

### DIFF
--- a/Classes/ShareKit/Sharers/Services/YouTube/SHKYouTube.m
+++ b/Classes/ShareKit/Sharers/Services/YouTube/SHKYouTube.m
@@ -312,7 +312,7 @@ NSString *const kKeychainItemName = @"ShareKit: YouTube";
                                  start:@"public"
                       optionPickerInfo:[NSMutableDictionary dictionaryWithDictionary:@{
                                         @"title":@"Privacy",
-                                        @"curIndexes":@"-1",
+                                        @"curIndexes":@"0",
                                         @"allowMultiple":@NO,
                                         @"itemsList":@[@"public",@"private",@"unlisted"],
                                         @"static":@YES


### PR DESCRIPTION
Public sharing on YouTube sharer was not working because even though the
UI showed "public" as the default setting, it was not actually selected
