### PR TITLE
Double fill hashtags and URL at first authentication

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -171,19 +171,23 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
 	{
 		status = self.item.shareType == SHKShareTypeText ? self.item.text : self.item.title;
 	}
-
-	NSString *hashtags = [self tagStringJoinedBy:@" " allowedCharacters:[NSCharacterSet alphanumericCharacterSet]
-	                                   tagPrefix:@"#" tagSuffix:nil];
-	if ([hashtags length] > 0)
-	{
-		status = [NSString stringWithFormat:@"%@ %@", status, hashtags];
-	}
+	
+	//Only add the additional tags / URL if user has authorized his account
+	if(self.isAuthorized) {
+		NSString *hashtags = [self tagStringJoinedBy:@" " allowedCharacters:[NSCharacterSet alphanumericCharacterSet]
+		                                   tagPrefix:@"#" tagSuffix:nil];
+		if ([hashtags length] > 0)
+		{
+			status = [NSString stringWithFormat:@"%@ %@", status, hashtags];
+		}
     
-    if (self.item.URL)
-    {
-        NSString *URLstring = [self.item.URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        status = [NSString stringWithFormat:@"%@ %@", status, URLstring];
-    }
+		if (self.item.URL)
+		{
+			NSString *URLstring = [self.item.URL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+			status = [NSString stringWithFormat:@"%@ %@", status, URLstring];
+		}	
+	}
+	
     
 	[self.item setCustomValue:status forKey:@"status"];
 }


### PR DESCRIPTION
When using the twitter forcePreIOS5TwitterAccess:true, the URL and Hashtags get double filled because prepareItem is called before and after authorization.
