### PR TITLE
Resolve crash with Twitter OAuth when user presses cancel

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
+++ b/Classes/ShareKit/Sharers/Services/Twitter/SHKTwitter.m
@@ -270,10 +270,9 @@ static NSString *const kSHKTwitterUserInfo=@"kSHKTwitterUserInfo";
         {
             if (accessToken.sessionHandle != nil)
                 [oRequest setOAuthParameterName:@"oauth_session_handle" withValue:accessToken.sessionHandle];
-        }
-		
-        else
+        } else if([authorizeResponseQueryVars objectForKey:@"oauth_verifier"]) {
             [oRequest setOAuthParameterName:@"oauth_verifier" withValue:[authorizeResponseQueryVars objectForKey:@"oauth_verifier"]];
+        }
     }
 }
 


### PR DESCRIPTION
Resolves issue #736 

Now displays the following error when the user presses cancel and no longer causes a crash. http://cl.ly/image/3E0h0r2c311Z
