### PR TITLE
Close button on VKontakte OAuth View

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakteOAuthView.m
+++ b/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakteOAuthView.m
@@ -47,11 +47,26 @@
 	
 }
 
+- (void) closeView
+{
+    [[SHK currentHelper] hideCurrentViewControllerAnimated:YES];
+}
+
+- (void) addCloseButton
+{
+    self.navigationItem.leftBarButtonItem = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonItemStyleBordered
+                                                                                           target:self
+                                                                                           action:@selector(closeView)]
+                                             autorelease];
+}
+
 #pragma mark - View lifecycle
 - (void)viewDidLoad
 {
 	[super viewDidLoad];
 	
+    [self addCloseButton];
+    
 	if(!vkWebView)
 	{
 		self.vkWebView = [[[UIWebView alloc] initWithFrame:self.view.bounds] autorelease];


### PR DESCRIPTION
The button is necessary if user want force close OAuth form.
