### PR TITLE
Allow ShareKit to look for resources in the main bundle as well.

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -718,6 +718,12 @@ NSString* SHKLocalizedStringFormat(NSString* key)
       }
       
       bundle = [[NSBundle bundleWithPath:path] retain];
+      
+      if (!bundle) {
+          NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"ShareKit.bundle" withExtension:nil];
+          bundle = [NSBundle bundleWithURL:bundleURL];
+      }
+      
       NSCAssert(bundle != nil,@"ShareKit has been refactored to be used as Xcode subproject. Please follow the updated installation wiki and re-add it to the project. Please do not forget to clean project and clean build folder afterwards. In case you use CocoaPods override - (NSNumber *)isUsingCocoaPods; method in your configurator subclass and return [NSNumber numberWithBool:YES]");
   }
   return [bundle localizedStringForKey:key value:key table:nil];


### PR DESCRIPTION
There are still some reasons to use workspace projects instead of subprojects. Getting ShareKit to work as a workspace project is very possible, but only if you add the ShareKit.bundle to the target project as well. 

This commit ensures that ShareKit still finds the appropriate bundle in this case.
