### PR TITLE
[ShareKit/remind101-master] Added method to instantiate actionsheet with sharers. Changed sharers property to readonly since it doesn't act as a read-write property.

### DIFF
--- a/Classes/ShareKit/UI/SHKActionSheet.h
+++ b/Classes/ShareKit/UI/SHKActionSheet.h
@@ -32,10 +32,11 @@
 
 @interface SHKActionSheet : UIActionSheet <UIActionSheetDelegate>
 
-@property (retain) NSMutableArray *sharers;
+@property (readonly) NSArray *sharers;
 @property (retain) SHKItem *item;
 @property (retain) id<SHKShareItemDelegate> shareDelegate;
 
-+ (SHKActionSheet *)actionSheetForItem:(SHKItem *)i;
++ (SHKActionSheet *)actionSheetForItem:(SHKItem *)item;
++ (SHKActionSheet *)actionSheetForItem:(SHKItem *)item withSharers:(NSArray *)sharers;
 
 @end


### PR DESCRIPTION
Originally, the .sharers property was (retain), and thus read-write and atomic. This doesn't actually match how SHKActionSheet functions however. Setting the sharers property put any object instantiated by this class in an inconsistent state.

Instead, I changed .sharers to readonly (and still atomic) and added the method
'+ (SHKActionSheet *)actionSheetForItem:(SHKItem *)item withSharers:(NSArray *)sharers'
which is now the default allocator amongst the two provided in the API. Providing a nil 'sharers' parameter will default sharers to the 'favoriteSharersForItem:'
