### PR TITLE
Fixed Facebook authorization errors handling

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebook.m
@@ -177,20 +177,31 @@ static SHKFacebook *requestingPermisSHKFacebook=nil;
         NSString *errorReason = [error.userInfo objectForKey:FBErrorLoginFailedReason];
         
         // If error is not caused by cancelling authorization by the user -> show alert
-        if ([errorReason isEqual:FBErrorLoginFailedReasonUserCancelledSystemValue] || [errorReason isEqualToString:FBErrorLoginFailedReasonUserCancelledValue]) {
-            //we don't need to show error in this case
-        }
-        else if ([errorReason isEqualToString:FBErrorLoginFailedReasonSystemDisallowedWithoutErrorValue]) {
-            //ios 6 system facebook login is disabled in settings for this app.
-            UIAlertView *alertView = [[UIAlertView alloc]
-                                      initWithTitle:@"Could not login with Facebook"
-                                      message:@"Please check your Facebook settings on your phone. Maybe this app is disallowed to use with Facebook."
-                                      delegate:nil
-                                      cancelButtonTitle:@"OK"
-                                      otherButtonTitles:nil];
-            [alertView show];
-            [alertView release];
-        }
+        if (![errorReason isEqual:FBErrorLoginFailedReasonUserCancelledSystemValue] && ![errorReason isEqualToString:FBErrorLoginFailedReasonUserCancelledValue]) {
+
+            //we need to show alert only if the reason of error is not caused by user decision to cancel it
+            if ([errorReason isEqualToString:FBErrorLoginFailedReasonSystemDisallowedWithoutErrorValue]) {
+                //ios 6 system facebook login is disabled in settings for this app.
+                UIAlertView *alertView = [[UIAlertView alloc]
+                                          initWithTitle:@"Could not login with Facebook"
+                                          message:@"Please check your Facebook settings on your phone. Maybe this app is disallowed to use with Facebook."
+                                          delegate:nil
+                                          cancelButtonTitle:@"OK"
+                                          otherButtonTitles:nil];
+                [alertView show];
+                [alertView release];
+            }
+            else {
+                UIAlertView *alertView = [[UIAlertView alloc]
+                                          initWithTitle:@"Error"
+                                          message:error.localizedDescription
+                                          delegate:nil
+                                          cancelButtonTitle:@"OK"
+                                          otherButtonTitles:nil];
+                [alertView show];
+                [alertView release];
+            }
+        }        
     }
 	if (authingSHKFacebook == self) {
 		authingSHKFacebook = nil;


### PR DESCRIPTION
Removed alert with facebook.sdk.error 2 in the case when user cancels the login in webview. Handling situation when user disallowed current app to be used with facebook in iOS device's system preferences
