### PR TITLE
Fix for issue #774: Dropbox pushing file up preserves entire path to loc...

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Dropbox/SHKDropbox.m
+++ b/Classes/ShareKit/Sharers/Services/Dropbox/SHKDropbox.m
@@ -415,7 +415,7 @@ static int outstandingRequests = 0;
     if (__fileOffset < __fileSize) {
         [client uploadFileChunk:uploadId offset:__fileOffset fromPath:localPath];
     } else {
-        NSString *fileName = self.item.file.path;
+        NSString *fileName = [self.item customValueForKey:kSHKDropboxStoredFileName];
         if (fileName.length < 1) {
             fileName = [NSString stringWithFormat:@"ShareKit-file-%lu", random() % 200];
         }


### PR DESCRIPTION
...al file instead of just filename. Use kSHKDropboxStoredFileName for filename instead of entire path.
