### PR TITLE
Added semi-colons to the end of the lines for Tweet and Message strings in English localization.

### DIFF
--- a/Classes/ShareKit/ShareKit.bundle/en.lproj/Localizable.strings
+++ b/Classes/ShareKit/ShareKit.bundle/en.lproj/Localizable.strings
@@ -272,7 +272,7 @@
 "Comment" = "Comment";
 
 //twitter text filed placeholder
-"Tweet" = "Tweet"
+"Tweet" = "Tweet";
 
 //universal
-"Message" = "Message"
+"Message" = "Message";


### PR DESCRIPTION
//twitter text filed placeholder
 "Tweet" = "Tweet";

 //universal
 "Message" = "Message";

Fixes warning I was seeing:
CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 278. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
