### PR TITLE
NEW FEATURE: ability to write appName in metadata when sharing via SHKPhotoAlbum

### DIFF
--- a/Classes/ShareKit/Configuration/DefaultSHKConfigurator.h
+++ b/Classes/ShareKit/Configuration/DefaultSHKConfigurator.h
@@ -111,6 +111,8 @@
 - (NSNumber*)isMailHTML;
 - (NSNumber*)mailJPGQuality;
 - (NSNumber*)sharedWithSignature;
+//SHKPhotoAlbum
+- (NSNumber*)photoAlbumShouldWriteMetadata;
 //SHKFacebook
 - (NSString *)facebookURLSharePictureURI;
 - (NSString *)facebookURLShareDescription;

--- a/Classes/ShareKit/Configuration/DefaultSHKConfigurator.m
+++ b/Classes/ShareKit/Configuration/DefaultSHKConfigurator.m
@@ -541,6 +541,13 @@
 	return [NSNumber numberWithInt:0];
 }
 
+/* SHKPhotoAlbum */
+
+- (NSNumber*)photoAlbumShouldWriteMetadata
+{
+    return @NO;
+}
+
 /* SHKFacebook */
 
 //when you share URL on Facebook, FBDialog scans the page and fills picture and description automagically by default. Use these item properties to set your own.

--- a/ShareKit demo app.xcodeproj/project.pbxproj
+++ b/ShareKit demo app.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5B9C17AA1803F486002200C1 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B9C17A81803F486002200C1 /* ImageIO.framework */; };
+		5B9C17AB1803F486002200C1 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B9C17A91803F486002200C1 /* AssetsLibrary.framework */; };
 		7A0406671740E3F6003404B9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A0406661740E3F6003404B9 /* UIKit.framework */; };
 		7A0406691740E3F6003404B9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A0406681740E3F6003404B9 /* Foundation.framework */; };
 		7A04066B1740E3F6003404B9 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A04066A1740E3F6003404B9 /* CoreGraphics.framework */; };
@@ -365,6 +367,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5B9C17A81803F486002200C1 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk/System/Library/Frameworks/ImageIO.framework; sourceTree = "<absolute>"; };
+		5B9C17A91803F486002200C1 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk/System/Library/Frameworks/AssetsLibrary.framework; sourceTree = "<absolute>"; };
 		7A0406631740E3F6003404B9 /* ShareKit demo app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ShareKit demo app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A0406661740E3F6003404B9 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		7A0406681740E3F6003404B9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -429,6 +433,7 @@
 				7A85B55F17FA220100C86E77 /* libxml2.dylib in Frameworks */,
 				7AD7D5C917EC46E300DE20F6 /* StoreKit.framework in Frameworks */,
 				7AD7D5CB17EC5A8200DE20F6 /* FacebookSDK.framework in Frameworks */,
+				5B9C17AB1803F486002200C1 /* AssetsLibrary.framework in Frameworks */,
 				7A0FB85017A4460C00B88C87 /* libShareKit.a in Frameworks */,
 				7A040832174133C5003404B9 /* Social.framework in Frameworks */,
 				7A04076A17410472003404B9 /* QuartzCore.framework in Frameworks */,
@@ -447,6 +452,7 @@
 				7A040750174103E4003404B9 /* SystemConfiguration.framework in Frameworks */,
 				7A0406671740E3F6003404B9 /* UIKit.framework in Frameworks */,
 				7A0406691740E3F6003404B9 /* Foundation.framework in Frameworks */,
+				5B9C17AA1803F486002200C1 /* ImageIO.framework in Frameworks */,
 				7A04066B1740E3F6003404B9 /* CoreGraphics.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -476,6 +482,8 @@
 		7A0406651740E3F6003404B9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5B9C17A81803F486002200C1 /* ImageIO.framework */,
+				5B9C17A91803F486002200C1 /* AssetsLibrary.framework */,
 				7A85B53317FA1FD900C86E77 /* libxml2.dylib */,
 				7AD7D63517EC75FE00DE20F6 /* DropboxSDK.framework */,
 				7AD7D5CA17EC5A8200DE20F6 /* FacebookSDK.framework */,

--- a/ShareKit demo app/ShareKitDemoConfigurator.m
+++ b/ShareKit demo app/ShareKitDemoConfigurator.m
@@ -312,4 +312,11 @@
     return nil;
 }
 
+/* Write appName to metadata when share to PhotoLibrary */
+
+- (NSNumber *)photoAlbumShouldWriteMetadata
+{
+    return @YES;
+}
+
 @end

--- a/ShareKit.xcodeproj/project.pbxproj
+++ b/ShareKit.xcodeproj/project.pbxproj
@@ -775,6 +775,8 @@
 		456BAD1016910707005B3077 /* libGooglePlusUniversal.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libGooglePlusUniversal.a; sourceTree = "<group>"; };
 		456BADA9169107D1005B3077 /* SHKGooglePlus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SHKGooglePlus.h; path = "Google Plus/SHKGooglePlus.h"; sourceTree = "<group>"; };
 		456BADAA169107D1005B3077 /* SHKGooglePlus.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SHKGooglePlus.m; path = "Google Plus/SHKGooglePlus.m"; sourceTree = "<group>"; };
+		5B9C17A11803F453002200C1 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
+		5B9C17A51803F460002200C1 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 		7A0F91CD156B9FF2009CB40A /* SHKDelicious.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SHKDelicious.h; path = Delicious/SHKDelicious.h; sourceTree = "<group>"; };
 		7A0F91CE156B9FF2009CB40A /* SHKDelicious.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = SHKDelicious.m; path = Delicious/SHKDelicious.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		7A0F9246156BA2A0009CB40A /* libShareKitCore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libShareKitCore.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1564,6 +1566,8 @@
 				43EF406D11D3FFF800B1F700 /* Security.framework */,
 				43D1DEEF11D5CDD200550D75 /* SystemConfiguration.framework */,
 				7AB535EF1552E12100171BCE /* CoreFoundation.framework */,
+				5B9C17A11803F453002200C1 /* ImageIO.framework */,
+				5B9C17A51803F460002200C1 /* AssetsLibrary.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";


### PR DESCRIPTION
When sharing via SHKPhotoAlbum action added writing appName as kCGImagePropertyTIFFSoftware metadata key. It helpful when you want to identify which images was created by your application.

Note that it requires adding ImageIO and AssetsLibrary frameworks.
