### PR TITLE
Missing dependency in Sharekit.Podspec for Google Plus

### DIFF
--- a/ShareKit.podspec
+++ b/ShareKit.podspec
@@ -167,6 +167,7 @@ Pod::Spec.new do |s|
     googleplus.dependency 'ShareKit/Core'
     googleplus.dependency 'Google-API-Client/Common'
     googleplus.dependency 'Google-API-Client/Objects'
+    googleplus.dependency 'Google-API-Client/Utilities'
     googleplus.dependency 'Google-API-Client/Services/Plus'
     googleplus.dependency 'OpenInChrome'
     googleplus.dependency 'gtm-logger'


### PR DESCRIPTION
There are couple of lines missing in Sharekit.Podspec.
