### PR TITLE
Fixed Vkontakte web view hanging in the case of unavailable network - tr...

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakteOAuthView.m
+++ b/Classes/ShareKit/Sharers/Services/Vkontakte/SHKVkontakteOAuthView.m
@@ -76,11 +76,15 @@
 		[[SHK currentHelper] hideCurrentViewControllerAnimated:YES];
 		return;
 	}
-	NSString *authLink = [NSString stringWithFormat:@"http://api.vk.com/oauth/authorize?client_id=%@&scope=wall,photos,friends,offline,docs&redirect_uri=http://api.vk.com/blank.html&display=touch&response_type=token", appID];
-	NSURL *url = [NSURL URLWithString:authLink];
-	
-	[vkWebView loadRequest:[NSURLRequest requestWithURL:url]];
-	
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    NSString *authLink = [NSString stringWithFormat:@"http://api.vk.com/oauth/authorize?client_id=%@&scope=wall,photos,friends,offline,docs&redirect_uri=http://api.vk.com/blank.html&display=touch&response_type=token", appID];
+    NSURL *url = [NSURL URLWithString:authLink];
+
+    [vkWebView loadRequest:[NSURLRequest requestWithURL:url]];
 }
 
 - (void)viewDidUnload


### PR DESCRIPTION
Fixed Vkontakte web view hanging in the case of unavailable network - tried to dismiss modal controller during presentation.

When there is no internet connection, webview:didFailLoadWithError: was called before view controller was finally presented.
