### PR TITLE
SHKFacebook. Login flow: Fixed authenticatoin bug in ios 6-7 — sharerAuthDidFinish was called sometimes with FBSession that has invalid access token (in the case of token expiration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build
 .DS_Store
 Classes/ShareKit/SHKConfig.h
 DerivedData
+
+# Appcode temp files ignore
+.idea/*

--- a/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebookCommon.h
+++ b/Classes/ShareKit/Sharers/Services/Facebook/SHKFacebookCommon.h
@@ -29,4 +29,9 @@ extern NSString *const kSHKFacebookAPIVideosURL;
 + (NSMutableDictionary *)composeParamsForItem:(SHKItem *)item;
 + (NSMutableArray *)shareFormFieldsForItem:(SHKItem *)item;
 
+/**
+* Testing current opened session, if it's access token is not valid, try to reopen session
+*/
++ (void)refreshCurrentAccessTokenIfNeededWithCompletionBlock:(void (^)(NSError *))completion;
+
 @end


### PR DESCRIPTION
Hello!
https://developers.facebook.com/docs/facebook-login/testing-your-login-flow/
I had read this article in facebook documentation and figured out that some cases are not covered in SHKFacebook login logic. For example if user has disabled Facebook application via app settings.

In this case during authentication in iOS 6.0+ FBSession gets invalid accessToken 
(app is removed from facebook app settings and is not authorized now). 
So when Sharekit calls [FBSession openActiveSessionWithReadPermissions:...], the iOS 6+ device may think the old token is valid and will let the state go to Open, and success gets called. But it is already expired actually.

Then authentication error will only occure after calling next Facebook request call.
So for being sure that access token is surely valid, I test Facebook request with opened session and check response.
If access token validation error occured - we are trying to reopen session again.

I stuck with this for 2 days and solution is finally found (I hope:))

Thanks for any comments
