### PR TITLE
Fix Analyzer warning

### DIFF
--- a/Classes/ShareKit/Core/Helpers/SHKFile.m
+++ b/Classes/ShareKit/Core/Helpers/SHKFile.m
@@ -239,7 +239,7 @@ static NSString *kSHKFileData = @"kSHKFileData";
 - (NSString *)MIMETypeForPath:(NSString *)path{
     
     NSString *result = @"";
-    CFStringRef uti = [self UTITypeForPath:path];
+    CFStringRef uti = CreateUTITypeForPath(path);
     if (uti) {
         CFStringRef cfMIMEType = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType);
         if (cfMIMEType) {
@@ -250,7 +250,7 @@ static NSString *kSHKFileData = @"kSHKFileData";
     return result;
 }
 
-- (CFStringRef)UTITypeForPath:(NSString *)path {
+CFStringRef CreateUTITypeForPath(NSString *path) {
     
     NSString *extension = [path pathExtension];
     CFStringRef result = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
@@ -260,7 +260,7 @@ static NSString *kSHKFileData = @"kSHKFileData";
 - (NSString *)NSStringUTITypeForPath:(NSString *)path {
     
     NSString *result = nil;
-    CFStringRef uti = [self UTITypeForPath:path];
+    CFStringRef uti = CreateUTITypeForPath(path);
     if (uti) {
         result = CFBridgingRelease(uti);
     }


### PR DESCRIPTION
Fix the following Analyzer warning:

```
ShareKit/Classes/ShareKit/Core/Helpers/SHKFile.m:257:5: Potential leak of an object stored into 'result'
```

By converting the `UTITypeForPath:` method into a "`Create`" function `CreateUTITypeForPath` as suggested here http://stackoverflow.com/a/8628172/1049134
