### PR TITLE
Ease SHKActionSheet subclassing

### DIFF
--- a/Classes/ShareKit/UI/SHKActionSheet.h
+++ b/Classes/ShareKit/UI/SHKActionSheet.h
@@ -34,7 +34,7 @@
 
 @property (strong) id<SHKShareItemDelegate> shareDelegate;
 
-+ (SHKActionSheet *)actionSheetForItem:(SHKItem *)i;
++ (instancetype)actionSheetForItem:(SHKItem *)i;
 
 - (NSMutableArray *)sharersToShow;
 - (void)populateButtons;

--- a/Classes/ShareKit/UI/SHKActionSheet.m
+++ b/Classes/ShareKit/UI/SHKActionSheet.m
@@ -43,7 +43,7 @@
 
 @implementation SHKActionSheet
 
-- (id)initWithItem:(SHKItem *)item {
+- (instancetype)initWithItem:(SHKItem *)item {
     
     self = [super initWithTitle:SHKLocalizedString(@"Share")
                        delegate:nil
@@ -57,9 +57,9 @@
     return self;
 }
 
-+ (SHKActionSheet *)actionSheetForItem:(SHKItem *)item
++ (instancetype)actionSheetForItem:(SHKItem *)item
 {
-	SHKActionSheet *as = [[SHKActionSheet alloc] initWithItem:item];
+	SHKActionSheet *as = [[self alloc] initWithItem:item];
 	as.delegate = as;
 	as.sharers = [as sharersToShow];
     [as populateButtons];


### PR DESCRIPTION
- Use `[self alloc]` to allow correctly instantiating subclasses.
- Prefer `instancetype` to `id` (other code should also be updated)
