### PR TITLE
Fix build error

### DIFF
--- a/ShareKit.podspec
+++ b/ShareKit.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
     core.dependency 'SAMTextView', '~> 0.2.1'
     core.dependency 'ShareKit/Reachability'
     core.dependency 'ShareKit/NoARC'
+    core.dependency 'UIActivityIndicator-for-SDWebImage'
   end
 
   s.subspec 'NoARC' do |noarc|


### PR DESCRIPTION
I get the following error when I use ShareKit from CocoaPods:

/Users/stephend/Documents/Development/iPhone/Code/App/Pods/ShareKit/Classes/ShareKit/UI/SHKFormFieldLargeTextSettings.m:12:9: fatal error: 'UIImageView+UIActivityIndicatorForSDWebImage.h' file not found
# import "UIImageView+UIActivityIndicatorForSDWebImage.h"

```
    ^
```

1 error generated.

The attached patch adds the appropriate packages so that SDWebImage and a category get installed correctly.
