### PR TITLE
SHKFormOptionController done method now calls SHKFormOptionControllerCan...

### DIFF
--- a/Classes/ShareKit/UI/SHKFormOptionController.m
+++ b/Classes/ShareKit/UI/SHKFormOptionController.m
@@ -112,6 +112,9 @@
 
 - (IBAction)done:(id)sender {
 	
+    if (self.provider != nil) {
+    	[self.provider SHKFormOptionControllerCancelEnumerateOptions:self];
+    }	
     [self.client SHKFormOptionControllerDidFinish:self];
 }
 


### PR DESCRIPTION
...celEnumerateOptions

In case there is a pending request to update the list of options, but the user selects an option before the request completes, we need to call SHKFormOptionControllerCancelEnumerateOptions just like we do within the cancel method.
