### PR TITLE
Fix check for Dropbox URL scheme

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Dropbox/SHKDropbox.m
+++ b/Classes/ShareKit/Sharers/Services/Dropbox/SHKDropbox.m
@@ -84,7 +84,7 @@ static NSString *const kSHKDropboxDestinationDirKeyName = @"kSHKDropboxDestinati
         NSString *scheme = nil;
         
         for (NSDictionary *schemeDict in urlTypes) {
-            if ([schemeDict isKindOfClass:[NSDictionary class]] == YES && [@"Dropbox" isEqualToString:[schemeDict objectForKey:@"CFBundleTypeRole"]] == YES) {
+            if ([schemeDict isKindOfClass:[NSDictionary class]] == YES && ([@"Dropbox" isEqualToString:[schemeDict objectForKey:@"CFBundleTypeRole"]] == YES || ([@"Editor" isEqualToString:[schemeDict objectForKey:@"CFBundleTypeRole"]] == YES &&  [@"Dropbox" isEqualToString:[schemeDict objectForKey:@"CFBundleURLName"]] == YES))) {
                 scheme = [[schemeDict objectForKey:@"CFBundleURLSchemes"] lastObject];
                 break;
             }


### PR DESCRIPTION
When you set up a URL scheme in Xcode, it's in a different format than is expected in the Dropbox sharer. Honestly, the old one looks wrong but I left it in in case it's from an old version of iOS.
