### PR TITLE
Localization fix if used as pod

### DIFF
--- a/Classes/ShareKit/Core/SHK.m
+++ b/Classes/ShareKit/Core/SHK.m
@@ -794,6 +794,12 @@ NSString* SHKLocalizedStringFormat(NSString* key)
       
       NSString *path = [SHK shareKitLibraryBundlePath];
       bundle = [NSBundle bundleWithPath:path];
+      
+      if ([SHKCONFIG(isUsingCocoaPods) boolValue]) {
+          NSString *language = [NSLocale preferredLanguages][0];
+          bundle = [NSBundle bundleWithPath:[bundle pathForResource:language ofType:@"lproj"]];
+      }
+      
       NSCAssert(bundle != nil,@"ShareKit has been refactored to be used as Xcode subproject. Please follow the updated installation wiki and re-add it to the project. Please do not forget to clean project and clean build folder afterwards. In case you use CocoaPods override - (NSNumber *)isUsingCocoaPods; method in your configurator subclass and return [NSNumber numberWithBool:YES]");
   }
   NSString *result = [bundle localizedStringForKey:key value:nil table:nil];


### PR DESCRIPTION
Localized strings cannot be found in ShareKit bundle without specifying path to .lproj folder.
