### PR TITLE
Added isTextMessageHTML property to be able to control if SMS line breaks shall be made using "<BR/>"  or "\n".

### DIFF
--- a/Classes/ShareKit/Configuration/DefaultSHKConfigurator.h
+++ b/Classes/ShareKit/Configuration/DefaultSHKConfigurator.h
@@ -133,6 +133,7 @@
 - (NSString *)facebookURLShareDescription;
 //SHKTextMessage
 - (NSArray *)textMessageToRecipients;
+- (NSNumber*)isTextMessageHTML;
 //SHKInstagram and future others
 -(NSString*) popOverSourceRect;
 //SHKDropbox

--- a/Classes/ShareKit/Configuration/DefaultSHKConfigurator.m
+++ b/Classes/ShareKit/Configuration/DefaultSHKConfigurator.m
@@ -643,6 +643,10 @@ on the auth path. It will try to use native auth if availible.
   return nil;
 }
 
+- (NSNumber*)isTextMessageHTML {
+    return [NSNumber numberWithInt:1];
+}
+
 -(NSString*) popOverSourceRect;
  {
   return NSStringFromCGRect(CGRectZero);

--- a/Classes/ShareKit/Core/SHKItem.h
+++ b/Classes/ShareKit/Core/SHKItem.h
@@ -139,6 +139,7 @@ typedef enum
 
 /* SHKTextMessage */
 @property (nonatomic, strong) NSArray *textMessageToRecipients;
+@property BOOL isTextMessageHTML;
 
 /* put in for SHKInstagram, but could be useful in some other place. This is the rect in the coordinates of the view of the viewcontroller set with
  setRootViewController: where a popover should eminate from. If this isn't provided the popover will be presented from the top left. */

--- a/Classes/ShareKit/Core/SHKItem.m
+++ b/Classes/ShareKit/Core/SHKItem.m
@@ -69,6 +69,7 @@ NSString * const SHKAttachmentSaveDir = @"SHKAttachmentSaveDir";
     _facebookURLSharePictureURI = SHKCONFIG(facebookURLSharePictureURI);
     
     _textMessageToRecipients = SHKCONFIG(textMessageToRecipients);
+	_isTextMessageHTML = [SHKCONFIG(isTextMessageHTML) boolValue];
 	_popOverSourceRect = CGRectFromString(SHKCONFIG(popOverSourceRect));
     
     _dropboxDestinationDirectory = SHKCONFIG(dropboxDestinationDirectory);
@@ -232,6 +233,7 @@ static NSString *kSHKMailShareWithAppSignature = @"kSHKMailShareWithAppSignature
 static NSString *kSHKFacebookURLShareDescription = @"kSHKFacebookURLShareDescription";
 static NSString *kSHKFacebookURLSharePictureURI = @"kSHKFacebookURLSharePictureURI";
 static NSString *kSHKTextMessageToRecipients = @"kSHKTextMessageToRecipients";
+static NSString *kSHKIsTextMessageHTML = @"kSHKIsTextMessageHTML";
 static NSString *kSHKPopOverSourceRect = @"kSHKPopOverSourceRect";
 static NSString *kSHKDropboxDestinationDir = @"kSHKDropboxDestinationDir";
 
@@ -260,6 +262,7 @@ static NSString *kSHKDropboxDestinationDir = @"kSHKDropboxDestinationDir";
         _facebookURLShareDescription = [decoder decodeObjectForKey:kSHKFacebookURLShareDescription];
         _facebookURLSharePictureURI = [decoder decodeObjectForKey:kSHKFacebookURLSharePictureURI];
         _textMessageToRecipients = [decoder decodeObjectForKey:kSHKTextMessageToRecipients];
+        _isTextMessageHTML = [decoder decodeBoolForKey:kSHKIsTextMessageHTML];
         _popOverSourceRect = CGRectFromString([decoder decodeObjectForKey:kSHKPopOverSourceRect]);
         _dropboxDestinationDirectory = [decoder decodeObjectForKey:kSHKDropboxDestinationDir];
     }
@@ -290,6 +293,7 @@ static NSString *kSHKDropboxDestinationDir = @"kSHKDropboxDestinationDir";
     [encoder encodeObject:self.facebookURLSharePictureURI forKey:kSHKFacebookURLSharePictureURI];
 #pragma clang diagnostic pop
     [encoder encodeObject:self.textMessageToRecipients forKey:kSHKTextMessageToRecipients];
+    [encoder encodeBool:self.isTextMessageHTML forKey:kSHKIsTextMessageHTML];
     [encoder encodeObject:NSStringFromCGRect(self.popOverSourceRect) forKey:kSHKPopOverSourceRect];
     [encoder encodeObject:self.dropboxDestinationDirectory forKey:kSHKDropboxDestinationDir];
 }
@@ -314,6 +318,7 @@ static NSString *kSHKDropboxDestinationDir = @"kSHKDropboxDestinationDir";
                                                     mailJPGQuality: %f\n\
                                                     mailShareWithAppSignature: %i\n\
                                                     textMessageToRecipients: %@\n\
+                                                    isTextMessageHTML: %i\n\
                                                     popOverSourceRect: %@\n\
                                                     dropboxDestinationDir: %@",
                         
@@ -333,6 +338,7 @@ static NSString *kSHKDropboxDestinationDir = @"kSHKDropboxDestinationDir";
                                                     self.mailJPGQuality,
                                                     self.mailShareWithAppSignature,
                                                     self.textMessageToRecipients,
+                                                    self.isTextMessageHTML,
 													NSStringFromCGRect(self.popOverSourceRect),
                                                     self.dropboxDestinationDirectory];
     return result;

--- a/Classes/ShareKit/Sharers/Actions/Text Message/SHKTextMessage.m
+++ b/Classes/ShareKit/Sharers/Actions/Text Message/SHKTextMessage.m
@@ -143,7 +143,9 @@
     
     NSString *result = nil;
     if (body) {
-        result = [body stringByAppendingFormat:@"<br/><br/>%@", string];
+		const BOOL isHTML = self.item.isTextMessageHTML;
+        NSString * const separator = (isHTML ? @"<br/><br/>" : @"\n\n");
+        result = [body stringByAppendingFormat:@"%@%@", separator, string];
     } else {
         result = string;
     }


### PR DESCRIPTION
We got HTML line break tags in iMessage messages.
