### PR TITLE
Tumblr: fixes broken sharing- updated to use https

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Tumblr/SHKTumblr.m
+++ b/Classes/ShareKit/Sharers/Services/Tumblr/SHKTumblr.m
@@ -86,9 +86,9 @@ NSString * const kSHKTumblrUserInfo = @"kSHKTumblrUserInfo";
 		self.secretKey = SHKCONFIG(tumblrSecret);
  		self.authorizeCallbackURL = [NSURL URLWithString:SHKCONFIG(tumblrCallbackUrl)];
 		
-	    self.requestURL = [NSURL URLWithString:@"http://www.tumblr.com/oauth/request_token"];
-	    self.authorizeURL = [NSURL URLWithString:@"http://www.tumblr.com/oauth/authorize"];
-	    self.accessURL = [NSURL URLWithString:@"http://www.tumblr.com/oauth/access_token"];
+	    self.requestURL = [NSURL URLWithString:@"https://www.tumblr.com/oauth/request_token"];
+	    self.authorizeURL = [NSURL URLWithString:@"https://www.tumblr.com/oauth/authorize"];
+	    self.accessURL = [NSURL URLWithString:@"https://www.tumblr.com/oauth/access_token"];
 		
 		self.signatureProvider = [[OAHMAC_SHA1SignatureProvider alloc] init];
 	}	


### PR DESCRIPTION
I'm getting in touch with Tumblr at this moment to update their docs. Integration is currently broken if you're still using http, even though that's what in their documentation.
