### PR TITLE
Diigo Login issue

### DIFF
--- a/Classes/ShareKit/Core/Helpers/SHKRequest.m
+++ b/Classes/ShareKit/Core/Helpers/SHKRequest.m
@@ -155,6 +155,25 @@
 	[self finish];
 }
 
+- (NSURLRequest *)connection: (NSURLConnection *)connection
+             willSendRequest: (NSURLRequest *)request
+            redirectResponse: (NSURLResponse *)redirectResponse;
+{
+    if (redirectResponse) {
+        NSURL* newURL = [request URL];
+        if ([self.request.URL user]) {
+            // copy over the username and password if there was one.
+            newURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@:%@@%@%@?%@", [newURL scheme], self.request.URL.user, self.request.URL.password, [newURL host], [newURL path], [newURL query]]];
+            
+        }
+        NSMutableURLRequest *r = [self.request mutableCopy];
+        [r setURL: newURL];
+        return r;
+    } else {
+        return request;
+    }
+}
+
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error 
 {
 	[self finish];


### PR DESCRIPTION
An issue logging into Diigo turns out to be because they changed their API so it redirects (301) before reaching the final destination. The username/password in this case is passed in using the URL which gets lost during the redirect, causing the log in to fail.

This fix keeps the username/password. However, I wonder if a better method might be for SHKRequest (or similar) to manage authentication details?
