### PR TITLE
Don't crash Pocket sharer if no title specified

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Pocket/SHKPocket.m
+++ b/Classes/ShareKit/Sharers/Services/Pocket/SHKPocket.m
@@ -126,7 +126,7 @@
     NSString *apiMethod = @"add";
     PocketAPIHTTPMethod httpMethod = PocketAPIHTTPMethodPOST; // usually PocketAPIHTTPMethodPOST
     NSDictionary *arguments = @{@"url": [self.item.URL absoluteString],
-                                @"title": self.item.title,
+                                @"title": self.item.title ?: @"",
                                 @"tags": tags};
     
     [[PocketAPI sharedAPI] callAPIMethod:apiMethod


### PR DESCRIPTION
If no title is supplied when posting to Pocket, it crashes. Put a blank title in instead.
