### PR TITLE
Make Flickr authentication work

### DIFF
--- a/Classes/ShareKit/Sharers/Services/Flickr/SHKFlickr.m
+++ b/Classes/ShareKit/Sharers/Services/Flickr/SHKFlickr.m
@@ -116,6 +116,11 @@
     return result;
 }
 
+- (void)tokenRequestModifyRequest:(OAMutableURLRequest *)oRequest
+{
+    [oRequest setOAuthParameterName:@"oauth_callback" withValue:[self.authorizeCallbackURL absoluteString]];
+}
+
 + (void)logout {
     
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kSHKFlickrUserInfo];


### PR DESCRIPTION
Flickr still appears to be using OAuth 1.0 rather than 1.0a.
