### PR TITLE
fixed linkedin scope name

### DIFF
--- a/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedIn.m
+++ b/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedIn.m
@@ -34,7 +34,7 @@
 NSString *SHKLinkedInVisibilityCodeKey = @"visibility.code";
 
 // The oauth scope we need to request at LinkedIn
-#define SHKLinkedInRequiredScope @"rw_nus"
+#define SHKLinkedInRequiredScope @"w_share"
 #define kSHKLinkedInUserInfo @"kSHKLinkedInUserInfo"
 #define URL_DESCRIPTION_LIMIT 256
 #define TITLE_LIMIT 200


### PR DESCRIPTION
It`s impossible to share via LinkedIn for new users, because of the deprecated scope name.

From LinkedIn documentation

https://developer.linkedin.com/support/developer-program-transition

New sharing permission

The rw_nus member permission will be deprecated.  Going forward, if your application shares content on behalf of a LinkedIn member, your application will require the w_share member permission to be granted.

The new w_share permission will grant you the permission to share content on LinkedIn as you could previously, however you will no longer be able to read shared content from a user's LinkedIn feed using the API.  We suggest you transition to using w_share as soon as possible, in anticipation of the upcoming changes.

Note that users with existing OAuth grants will have to re-authenticate due to the change in requested permissions.