### PR TITLE
Latest LinkedIn API requirements

### DIFF
--- a/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedIn.m
+++ b/Classes/ShareKit/Sharers/Services/LinkedIn/SHKLinkedIn.m
@@ -34,7 +34,7 @@
 NSString *SHKLinkedInVisibilityCodeKey = @"visibility.code";
 
 // The oauth scope we need to request at LinkedIn
-#define SHKLinkedInRequiredScope @"rw_nus"
+#define SHKLinkedInRequiredScope @"w_share r_basicprofile"
 #define kSHKLinkedInUserInfo @"kSHKLinkedInUserInfo"
 #define URL_DESCRIPTION_LIMIT 256
 #define TITLE_LIMIT 200


### PR DESCRIPTION
LinkedIn recently changed the permissions required to view profiles/post updates, which obviously affects ShareKit. In addition to this patch users will need to update their apps on the LinkedIn dev website.